### PR TITLE
Typed Alarm model + full alarm-state reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.0
+* **Typed alarm reads.** `getAlarms()` now returns `List<Alarm>` and `alarmUpdates()` emits `AlarmUpdateEvent`s, exposing each alarm's state, schedule (including recurrence weekdays), countdown durations, and persisted label/tint color.
+* Report **all** alarm states, including `countdown` and `alerting` (previously surfaced as `unknown`). Alarms with an unrecognized state or schedule are now kept (as `unknown`) instead of being silently dropped from `getAlarms()`.
+* `alarmUpdates()` now emits `update` events only when an alarm's state, schedule, or countdown duration actually changes.
+* Persisted alarm metadata (label/tint) is cleaned up on cancel and removal, so the App Group no longer accumulates orphaned entries.
+* **Breaking:** `getAlarms()` returns `Future<List<Alarm>>` (was `Future<List<Map<String, dynamic>>>`) and `alarmUpdates()` returns `Stream<AlarmUpdateEvent>` (was `Stream<dynamic>`).
+
 ## 0.2.0
 * Add **Swift Package Manager** support alongside CocoaPods.
 * The Live Activity Widget Extension no longer requires CocoaPods — it is a standalone WidgetKit target with no plugin dependency.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ See more: https://developer.apple.com/documentation/alarmkit
 - Schedule one-shot alarms
 - Schedule countdown alarms
 - Schedule recurrent alarms
-- Listen to alarm updates
+- Read scheduled alarms with their full state, schedule, and metadata (`getAlarms`)
+- Observe typed alarm add/update/remove events (`alarmUpdates`)
 - Set custom alarm sounds
 - Customize the Live Activity UI (buttons, icons, colors, titles)
 - Cancel alarms
@@ -59,15 +60,52 @@ try {
 }
 ```
 
+### Read scheduled alarms
+
+`getAlarms()` returns the alarms currently known to the system as typed
+[`Alarm`] objects — including each alarm's lifecycle state, schedule, countdown
+durations, and (for alarms scheduled through this plugin) its label and tint
+color:
+
+```dart
+final alarms = await FlutterAlarmkit().getAlarms();
+for (final alarm in alarms) {
+  print('${alarm.label} — ${alarm.state}'); // e.g. "Wake up — AlarmState.alerting"
+
+  switch (alarm.schedule) {
+    case FixedAlarmSchedule(:final date):
+      print('Fires once at $date');
+    case RelativeAlarmSchedule(:final hour, :final minute, :final weekdays):
+      print('Fires at $hour:$minute on $weekdays');
+    case UnknownAlarmSchedule():
+    case null:
+      break;
+  }
+}
+```
+
+`AlarmState` mirrors AlarmKit's states: `scheduled`, `countdown`, `paused`,
+`alerting`, and `unknown` (forward-compatible with future iOS states).
+
 ### Listen to alarm updates
 
-To listen to alarm updates (when alarms are added, updated, or removed):
+`alarmUpdates()` emits a typed `AlarmUpdateEvent` whenever an alarm is added,
+updated, or removed. `updated` events fire only when an alarm's state, schedule,
+or countdown duration actually changes:
 
 ```dart
 final stream = FlutterAlarmkit().alarmUpdates();
 
-stream.listen((alarmUpdate) {
-  print('Alarm updated: $alarmUpdate');
+stream.listen((event) {
+  switch (event.kind) {
+    case AlarmUpdateKind.added:
+    case AlarmUpdateKind.updated:
+      print('${event.alarmId} is now ${event.alarm?.state}');
+    case AlarmUpdateKind.removed:
+      print('${event.alarmId} was removed');
+    case AlarmUpdateKind.unknown:
+      break;
+  }
 });
 ```
 

--- a/example/lib/data/repositories/alarm_repository_impl.dart
+++ b/example/lib/data/repositories/alarm_repository_impl.dart
@@ -12,6 +12,16 @@ class AlarmRepositoryImpl implements AlarmRepository {
   }
 
   @override
+  Future<List<Alarm>> getAlarms() async {
+    return await _plugin.getAlarms();
+  }
+
+  @override
+  Stream<AlarmUpdateEvent> watchAlarms() {
+    return _plugin.alarmUpdates();
+  }
+
+  @override
   Future<String> scheduleOneShotAlarm({
     required DateTime timestamp,
     required String label,

--- a/example/lib/domain/repositories/alarm_repository.dart
+++ b/example/lib/domain/repositories/alarm_repository.dart
@@ -1,7 +1,14 @@
-import 'package:flutter_alarmkit/flutter_alarmkit.dart' show Weekday;
+import 'package:flutter_alarmkit/flutter_alarmkit.dart'
+    show Alarm, AlarmUpdateEvent, Weekday;
 
 abstract class AlarmRepository {
   Future<bool> requestAuthorization();
+
+  /// All alarms currently known to the system.
+  Future<List<Alarm>> getAlarms();
+
+  /// A stream of alarm add/update/remove events.
+  Stream<AlarmUpdateEvent> watchAlarms();
 
   Future<String> scheduleOneShotAlarm({
     required DateTime timestamp,

--- a/example/lib/presentation/bloc/alarm_bloc.dart
+++ b/example/lib/presentation/bloc/alarm_bloc.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter_alarmkit/flutter_alarmkit.dart';
 import '../../domain/repositories/alarm_repository.dart';
 
 // Events
@@ -68,18 +71,24 @@ class StopAlarm extends AlarmEvent {
   const StopAlarm({required this.alarmId});
 }
 
+/// Re-fetches the live alarm list. Dispatched on init and whenever the
+/// alarm-updates stream reports a change.
+class RefreshAlarms extends AlarmEvent {}
+
 // State
 class AlarmState extends Equatable {
   final String platformVersion;
   final String authStatus;
   final String scheduleStatus;
   final String? lastAlarmId;
+  final List<Alarm> alarms;
 
   const AlarmState({
     this.platformVersion = 'Unknown',
     this.authStatus = 'Not requested',
     this.scheduleStatus = 'No alarm scheduled',
     this.lastAlarmId,
+    this.alarms = const [],
   });
 
   AlarmState copyWith({
@@ -87,12 +96,14 @@ class AlarmState extends Equatable {
     String? authStatus,
     String? scheduleStatus,
     String? lastAlarmId,
+    List<Alarm>? alarms,
   }) {
     return AlarmState(
       platformVersion: platformVersion ?? this.platformVersion,
       authStatus: authStatus ?? this.authStatus,
       scheduleStatus: scheduleStatus ?? this.scheduleStatus,
       lastAlarmId: lastAlarmId ?? this.lastAlarmId,
+      alarms: alarms ?? this.alarms,
     );
   }
 
@@ -102,12 +113,14 @@ class AlarmState extends Equatable {
         authStatus,
         scheduleStatus,
         lastAlarmId,
+        alarms,
       ];
 }
 
 // BLoC
 class AlarmBloc extends Bloc<AlarmEvent, AlarmState> {
   final AlarmRepository _repository;
+  late final StreamSubscription<AlarmUpdateEvent> _alarmSubscription;
 
   AlarmBloc(this._repository) : super(const AlarmState()) {
     on<InitializeAlarm>(_onInitialize);
@@ -116,6 +129,20 @@ class AlarmBloc extends Bloc<AlarmEvent, AlarmState> {
     on<ScheduleCountdownAlarm>(_onScheduleCountdownAlarm);
     on<CancelAlarm>(_onCancelAlarm);
     on<StopAlarm>(_onStopAlarm);
+    on<RefreshAlarms>(_onRefreshAlarms);
+
+    // Subscribe before the first fetch so no update is missed; any system
+    // change re-fetches the authoritative list.
+    _alarmSubscription = _repository.watchAlarms().listen(
+          (_) => add(RefreshAlarms()),
+          onError: (Object _) {},
+        );
+  }
+
+  @override
+  Future<void> close() {
+    _alarmSubscription.cancel();
+    return super.close();
   }
 
   Future<void> _onInitialize(
@@ -128,6 +155,19 @@ class AlarmBloc extends Bloc<AlarmEvent, AlarmState> {
       emit(state.copyWith(platformVersion: version));
     } catch (e) {
       emit(state.copyWith(platformVersion: 'Failed to get platform version.'));
+    }
+    add(RefreshAlarms());
+  }
+
+  Future<void> _onRefreshAlarms(
+    RefreshAlarms event,
+    Emitter<AlarmState> emit,
+  ) async {
+    try {
+      final alarms = await _repository.getAlarms();
+      emit(state.copyWith(alarms: alarms));
+    } catch (_) {
+      // Likely not authorized yet (or iOS < 26); leave the list unchanged.
     }
   }
 
@@ -184,6 +224,7 @@ class AlarmBloc extends Bloc<AlarmEvent, AlarmState> {
         scheduleStatus: 'Alarm scheduled!',
         lastAlarmId: alarmId,
       ));
+      add(RefreshAlarms());
     } catch (e) {
       String status = 'Error: $e';
       if (e.toString().contains('UNSUPPORTED_VERSION')) {
@@ -234,6 +275,7 @@ class AlarmBloc extends Bloc<AlarmEvent, AlarmState> {
         scheduleStatus: 'Alarm scheduled!',
         lastAlarmId: alarmId,
       ));
+      add(RefreshAlarms());
     } catch (e) {
       emit(state.copyWith(scheduleStatus: 'Error: $e'));
     }
@@ -245,6 +287,7 @@ class AlarmBloc extends Bloc<AlarmEvent, AlarmState> {
   ) async {
     final canceled = await _repository.cancelAlarm(alarmId: event.alarmId);
     emit(state.copyWith(scheduleStatus: canceled ? 'Alarm canceled' : 'Error'));
+    add(RefreshAlarms());
   }
 
   Future<void> _onStopAlarm(
@@ -253,5 +296,6 @@ class AlarmBloc extends Bloc<AlarmEvent, AlarmState> {
   ) async {
     final stopped = await _repository.stopAlarm(alarmId: event.alarmId);
     emit(state.copyWith(scheduleStatus: stopped ? 'Alarm stopped' : 'Error'));
+    add(RefreshAlarms());
   }
 }

--- a/example/lib/presentation/screens/home_screen.dart
+++ b/example/lib/presentation/screens/home_screen.dart
@@ -4,6 +4,7 @@ import '../bloc/alarm_bloc.dart';
 import '../widgets/platform_info.dart';
 import '../widgets/permissions.dart';
 import '../widgets/alarm_controls.dart';
+import '../widgets/alarms_list.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -22,20 +23,22 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('AlarmKit Example 0.0.10')),
+      appBar: AppBar(title: const Text('AlarmKit Example')),
       body: BlocBuilder<AlarmBloc, AlarmState>(
         builder: (context, state) {
-          return Center(
+          return SingleChildScrollView(
             child: Padding(
               padding: const EdgeInsets.all(16.0),
               child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   PlatformInfo(platformVersion: state.platformVersion),
                   const SizedBox(height: 20),
                   const Permissions(),
                   const SizedBox(height: 40),
                   const AlarmControls(),
+                  const SizedBox(height: 32),
+                  const AlarmsList(),
                 ],
               ),
             ),

--- a/example/lib/presentation/widgets/alarm_controls.dart
+++ b/example/lib/presentation/widgets/alarm_controls.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_alarmkit/flutter_alarmkit.dart';
+// Hide the plugin's AlarmState enum: this file uses the bloc's AlarmState
+// (its state class) with BlocBuilder.
+import 'package:flutter_alarmkit/flutter_alarmkit.dart' hide AlarmState;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../bloc/alarm_bloc.dart';
 import 'status_container.dart';

--- a/example/lib/presentation/widgets/alarms_list.dart
+++ b/example/lib/presentation/widgets/alarms_list.dart
@@ -1,10 +1,177 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_alarmkit/flutter_alarmkit.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+// Prefixed: the bloc's AlarmState (state class) would otherwise clash with the
+// plugin's AlarmState enum used below.
+import '../bloc/alarm_bloc.dart' as bloc;
 
+/// Live list of the alarms currently known to the system, driven by
+/// `getAlarms()` and the `alarmUpdates()` stream.
 class AlarmsList extends StatelessWidget {
   const AlarmsList({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return BlocBuilder<bloc.AlarmBloc, bloc.AlarmState>(
+      builder: (context, state) {
+        if (state.alarms.isEmpty) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Text(
+              'No scheduled alarms',
+              style: TextStyle(color: Colors.grey),
+            ),
+          );
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'Scheduled alarms:',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+            ),
+            const SizedBox(height: 8),
+            ListView.separated(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: state.alarms.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 8),
+              itemBuilder: (context, index) =>
+                  _AlarmTile(alarm: state.alarms[index]),
+            ),
+          ],
+        );
+      },
+    );
   }
+}
+
+class _AlarmTile extends StatelessWidget {
+  const _AlarmTile({required this.alarm});
+
+  final Alarm alarm;
+
+  @override
+  Widget build(BuildContext context) {
+    final tint = _tintColor(alarm.tintColor);
+    return Card(
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        leading: tint == null
+            ? const Icon(Icons.alarm)
+            : CircleAvatar(backgroundColor: tint, radius: 12),
+        title: Text(alarm.label ?? '(no label)'),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 2),
+            Row(
+              children: [
+                Text(
+                  alarm.state.name,
+                  style: TextStyle(
+                    color: _stateColor(alarm.state),
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    _scheduleSummary(alarm),
+                    style: const TextStyle(fontSize: 12),
+                  ),
+                ),
+              ],
+            ),
+            Text(
+              'ID: ${_shortId(alarm.id)}',
+              style: const TextStyle(fontSize: 11, color: Colors.grey),
+            ),
+          ],
+        ),
+        trailing: IconButton(
+          icon: const Icon(Icons.delete_outline),
+          tooltip: 'Cancel',
+          onPressed: () => context
+              .read<bloc.AlarmBloc>()
+              .add(bloc.CancelAlarm(alarmId: alarm.id)),
+        ),
+      ),
+    );
+  }
+}
+
+Color _stateColor(AlarmState state) {
+  switch (state) {
+    case AlarmState.alerting:
+      return Colors.red;
+    case AlarmState.countdown:
+      return Colors.blue;
+    case AlarmState.paused:
+      return Colors.orange;
+    case AlarmState.scheduled:
+      return Colors.green;
+    case AlarmState.unknown:
+      return Colors.grey;
+  }
+}
+
+String _scheduleSummary(Alarm alarm) {
+  final schedule = alarm.schedule;
+  if (schedule is FixedAlarmSchedule) {
+    return 'Once · ${_formatDateTime(schedule.date)}';
+  }
+  if (schedule is RelativeAlarmSchedule) {
+    final time = '${_two(schedule.hour)}:${_two(schedule.minute)}';
+    if (schedule.weekdays.isEmpty) return 'Once · $time';
+    return '$time · ${_weekdayLabels(schedule.weekdays)}';
+  }
+  if (schedule is UnknownAlarmSchedule) {
+    return 'Unknown schedule';
+  }
+  final countdown = alarm.countdownDuration;
+  if (countdown != null) {
+    final pre = countdown.preAlert;
+    return pre != null ? 'Countdown · ${pre.round()}s' : 'Countdown';
+  }
+  return '—';
+}
+
+String _weekdayLabels(Set<Weekday> days) {
+  const names = {
+    Weekday.monday: 'Mon',
+    Weekday.tuesday: 'Tue',
+    Weekday.wednesday: 'Wed',
+    Weekday.thursday: 'Thu',
+    Weekday.friday: 'Fri',
+    Weekday.saturday: 'Sat',
+    Weekday.sunday: 'Sun',
+  };
+  // Order by enum index for a stable display.
+  return Weekday.values
+      .where(days.contains)
+      .map((day) => names[day])
+      .join(', ');
+}
+
+String _formatDateTime(DateTime date) =>
+    '${date.year}-${_two(date.month)}-${_two(date.day)} '
+    '${_two(date.hour)}:${_two(date.minute)}';
+
+String _two(int n) => n.toString().padLeft(2, '0');
+
+String _shortId(String id) => id.length <= 8 ? id : id.substring(0, 8);
+
+Color? _tintColor(String? hex) {
+  if (hex == null) return null;
+  var value = hex.trim();
+  if (value.startsWith('#')) value = value.substring(1);
+  if (value.length != 6) return null;
+  final parsed = int.tryParse(value, radix: 16);
+  if (parsed == null) return null;
+  return Color(0xFF000000 | parsed);
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.3.0"
   flutter_bloc:
     dependency: "direct main"
     description:

--- a/ios/flutter_alarmkit/Sources/flutter_alarmkit/Alarm+Extension.swift
+++ b/ios/flutter_alarmkit/Sources/flutter_alarmkit/Alarm+Extension.swift
@@ -4,12 +4,17 @@ import SwiftUI
 
 @available(iOS 26.0, *)
 extension Alarm {
-  func toDictionary() -> [String: Any]? {
+  /// Serializes this alarm into the dictionary contract consumed by the Dart
+  /// `Alarm.fromMap`. Never returns `nil`: an unrecognized state or schedule
+  /// kind is reported as `"unknown"` rather than dropping the alarm.
+  func toDictionary() -> [String: Any] {
       var dict: [String: Any] = [:]
       dict["id"] = self.id.uuidString
 
-      var scheduleDict: [String: Any] = [:]
+      // Schedule. A countdown timer has a nil schedule, in which case we omit
+      // the key entirely (the timing lives in `countdownDuration` below).
       if let schedule = self.schedule {
+          var scheduleDict: [String: Any] = [:]
           switch schedule {
           case .fixed(let date):
               scheduleDict["type"] = "fixed"
@@ -18,23 +23,80 @@ extension Alarm {
               scheduleDict["type"] = "relative"
               scheduleDict["hour"] = relativeSchedule.time.hour
               scheduleDict["minute"] = relativeSchedule.time.minute
+              switch relativeSchedule.repeats {
+              case .never:
+                  scheduleDict["weekdayMask"] = 0
+              case .weekly(let days):
+                  scheduleDict["weekdayMask"] = encodeWeekdays(days)
+              @unknown default:
+                  scheduleDict["weekdayMask"] = 0
+              }
           @unknown default:
-              return nil
+              scheduleDict["type"] = "unknown"
           }
-      } else {
-          // Countdown alarms have a nil schedule.
-          scheduleDict["type"] = "countdown"
+          dict["schedule"] = scheduleDict
       }
-      dict["schedule"] = scheduleDict
 
+      // Countdown timing, when present (each field is independently optional).
+      if let countdown = self.countdownDuration {
+          var countdownDict: [String: Any] = [:]
+          if let preAlert = countdown.preAlert {
+              countdownDict["preAlert"] = preAlert
+          }
+          if let postAlert = countdown.postAlert {
+              countdownDict["postAlert"] = postAlert
+          }
+          dict["countdownDuration"] = countdownDict
+      }
+
+      // State.
       switch self.state {
       case .scheduled:
           dict["state"] = "scheduled"
+      case .countdown:
+          dict["state"] = "countdown"
       case .paused:
           dict["state"] = "paused"
+      case .alerting:
+          dict["state"] = "alerting"
       @unknown default:
           dict["state"] = "unknown"
       }
+
+      // Presentation metadata (label + tint) is not readable back from
+      // AlarmKit, so the plugin persists it in the App Group at schedule time;
+      // merge it in here when available.
+      if let defaults = UserDefaults(suiteName: AlarmkitPluginImpl.appGroupId),
+         let meta = defaults.dictionary(forKey: "alarm_meta_\(self.id.uuidString)") {
+          if let label = meta["label"] as? String {
+              dict["label"] = label
+          }
+          if let tintColor = meta["tintColor"] as? String {
+              dict["tintColor"] = tintColor
+          }
+      }
+
       return dict
   }
-} 
+}
+
+/// Encodes AlarmKit weekdays back into the monday=bit0 bitmask used across the
+/// plugin (inverse of `decodeWeekdays` in `FlutterAlarmkitPlugin.swift`, and
+/// matching the Dart `Weekday.toBitmask` ordering).
+@available(iOS 26.0, *)
+private func encodeWeekdays(_ days: [Locale.Weekday]) -> Int {
+    var mask = 0
+    for day in days {
+        switch day {
+        case .monday: mask |= (1 << 0)
+        case .tuesday: mask |= (1 << 1)
+        case .wednesday: mask |= (1 << 2)
+        case .thursday: mask |= (1 << 3)
+        case .friday: mask |= (1 << 4)
+        case .saturday: mask |= (1 << 5)
+        case .sunday: mask |= (1 << 6)
+        @unknown default: break
+        }
+    }
+    return mask
+}

--- a/ios/flutter_alarmkit/Sources/flutter_alarmkit/AlarmUpdateStreamHandler.swift
+++ b/ios/flutter_alarmkit/Sources/flutter_alarmkit/AlarmUpdateStreamHandler.swift
@@ -8,48 +8,60 @@ class AlarmUpdateStreamHandler: NSObject, FlutterStreamHandler {
     func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
         // Cancel any existing subscription so a re-listen never orphans a Task.
         streamTask?.cancel()
-        // `previousAlarms` is kept local to this subscription so there is no
-        // mutable state shared between the platform thread and this Task.
+        // `previous` is kept local to this subscription so there is no mutable
+        // state shared between the platform thread and this Task. It maps each
+        // alarm id to a change-signature so we only emit `update` events when an
+        // alarm's state, schedule, or countdown actually changed.
         streamTask = Task {
-            var previousAlarms: Set<UUID> = []
+            var previous: [UUID: String] = [:]
             for await alarms in AlarmManager.shared.alarmUpdates {
                 if Task.isCancelled { break }
-                let currentAlarmIds = Set(alarms.map { $0.id })
 
-                // Find added alarms
-                let addedAlarms = currentAlarmIds.subtracting(previousAlarms)
-                for alarmId in addedAlarms {
-                    if let alarm = alarms.first(where: { $0.id == alarmId }) {
-                        var eventData: [String: Any] = [:]
-                        eventData["id"] = alarm.id.uuidString
-                        eventData["event"] = "add"
-                        eventData["alarm"] = alarm.toDictionary()
-                        DispatchQueue.main.async { events(eventData) }
+                // Serialize once per snapshot, reusing the dict for both the
+                // change-signature and the emitted payload.
+                var currentDicts: [UUID: [String: Any]] = [:]
+                var currentSignatures: [UUID: String] = [:]
+                for alarm in alarms {
+                    let dict = alarm.toDictionary()
+                    currentDicts[alarm.id] = dict
+                    currentSignatures[alarm.id] = AlarmUpdateStreamHandler.signature(from: dict)
+                }
+
+                let currentIds = Set(currentDicts.keys)
+                let previousIds = Set(previous.keys)
+
+                // Added alarms.
+                for id in currentIds.subtracting(previousIds) {
+                    if let dict = currentDicts[id] {
+                        AlarmUpdateStreamHandler.emit(
+                            ["id": id.uuidString, "event": "add", "alarm": dict],
+                            to: events
+                        )
                     }
                 }
 
-                // Find removed alarms
-                let removedAlarmIds = previousAlarms.subtracting(currentAlarmIds)
-                for alarmId in removedAlarmIds {
-                    var eventData: [String: Any] = [:]
-                    eventData["id"] = alarmId.uuidString
-                    eventData["event"] = "remove"
-                    DispatchQueue.main.async { events(eventData) }
+                // Removed alarms — also clean up persisted metadata, since the
+                // system can remove an alarm without an explicit cancel call.
+                for id in previousIds.subtracting(currentIds) {
+                    AlarmkitPluginImpl.removeAlarmPersistence(id.uuidString)
+                    AlarmUpdateStreamHandler.emit(
+                        ["id": id.uuidString, "event": "remove"],
+                        to: events
+                    )
                 }
 
-                // Find updated alarms (exist in both sets, state may have changed)
-                let existingAlarms = currentAlarmIds.intersection(previousAlarms)
-                for alarmId in existingAlarms {
-                    if let alarm = alarms.first(where: { $0.id == alarmId }) {
-                        var eventData: [String: Any] = [:]
-                        eventData["id"] = alarm.id.uuidString
-                        eventData["event"] = "update"
-                        eventData["alarm"] = alarm.toDictionary()
-                        DispatchQueue.main.async { events(eventData) }
+                // Updated alarms — only when the signature genuinely changed.
+                for id in currentIds.intersection(previousIds)
+                where previous[id] != currentSignatures[id] {
+                    if let dict = currentDicts[id] {
+                        AlarmUpdateStreamHandler.emit(
+                            ["id": id.uuidString, "event": "update", "alarm": dict],
+                            to: events
+                        )
                     }
                 }
 
-                previousAlarms = currentAlarmIds
+                previous = currentSignatures
             }
         }
         return nil
@@ -59,5 +71,26 @@ class AlarmUpdateStreamHandler: NSObject, FlutterStreamHandler {
         streamTask?.cancel()
         streamTask = nil
         return nil
+    }
+
+    /// A fingerprint of the change-relevant fields (state, schedule, countdown
+    /// duration). Label and tint are intentionally excluded: they are immutable
+    /// for a given alarm and must not trigger spurious `update` events.
+    private static func signature(from dict: [String: Any]) -> String {
+        let state = dict["state"] as? String ?? ""
+        var schedule = "none"
+        if let s = dict["schedule"] as? [String: Any] {
+            let type = s["type"] as? String ?? ""
+            schedule = "\(type)|\(s["timestamp"] ?? "")|\(s["hour"] ?? "")|\(s["minute"] ?? "")|\(s["weekdayMask"] ?? "")"
+        }
+        var countdown = "none"
+        if let c = dict["countdownDuration"] as? [String: Any] {
+            countdown = "\(c["preAlert"] ?? "")|\(c["postAlert"] ?? "")"
+        }
+        return "\(state)#\(schedule)#\(countdown)"
+    }
+
+    private static func emit(_ payload: [String: Any], to events: @escaping FlutterEventSink) {
+        DispatchQueue.main.async { events(payload) }
     }
 }

--- a/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
+++ b/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
@@ -156,6 +156,14 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     return UIColor(red: red, green: green, blue: blue, alpha: 1.0)
   }
 
+  /// Convert a SwiftUI `Color` into a `#RRGGBB` hex string.
+  private func hexString(from color: Color) -> String {
+    let uiColor = UIColor(color)
+    var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+    uiColor.getRed(&r, green: &g, blue: &b, alpha: &a)
+    return String(format: "#%02X%02X%02X", Int(r * 255), Int(g * 255), Int(b * 255))
+  }
+
   // MARK: - App Group
 
   static let appGroupId = "group.flutter-alarmkit"
@@ -236,6 +244,34 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
       tints["repeatTint"] = repeatButton.tintHexString
     }
     defaults.set(tints, forKey: "alarm_tints_\(alarmId)")
+  }
+
+  /// Persist the alarm's label and tint color in the App Group so they can be
+  /// returned later — AlarmKit does not expose presentation back to the app.
+  /// `createdAt` (epoch seconds) lets `getAlarms` prune orphans without racing
+  /// an in-flight schedule.
+  private func storeAlarmMeta(alarmId: String, label: String, tintColorHex: String, createdAt: TimeInterval) {
+    guard let defaults = UserDefaults(suiteName: AlarmkitPluginImpl.appGroupId) else {
+      NSLog("⚠️ Could not access App Group UserDefaults (\(AlarmkitPluginImpl.appGroupId)). Alarm label/tint will be unavailable from getAlarms().")
+      return
+    }
+    defaults.set(
+      ["label": label, "tintColor": tintColorHex, "createdAt": createdAt],
+      forKey: "alarm_meta_\(alarmId)"
+    )
+  }
+
+  /// Remove all persisted App Group state (meta + button tints) for an alarm.
+  private func removeAlarmPersistence(_ alarmId: String) {
+    AlarmkitPluginImpl.removeAlarmPersistence(alarmId)
+  }
+
+  /// Static variant of `removeAlarmPersistence`, usable from the alarm-updates
+  /// stream handler (which has no plugin instance).
+  static func removeAlarmPersistence(_ alarmId: String) {
+    guard let defaults = UserDefaults(suiteName: appGroupId) else { return }
+    defaults.removeObject(forKey: "alarm_meta_\(alarmId)")
+    defaults.removeObject(forKey: "alarm_tints_\(alarmId)")
   }
 
   // MARK: - Authorization
@@ -494,14 +530,26 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
         sound: resolveSoundAsset(soundPath),
     )
 
+    // Persist presentation metadata BEFORE scheduling so the alarm-updates
+    // stream's initial `add` event already carries the label/tint, and roll it
+    // back if scheduling fails.
+    let id = UUID()
+    storeAlarmMeta(
+      alarmId: id.uuidString,
+      label: label,
+      tintColorHex: hexString(from: tintColor),
+      createdAt: Date().timeIntervalSince1970
+    )
+    storeButtonTints(alarmId: id.uuidString, stop: stopConfig)
+
     do {
       let alarm = try await manager.schedule(
-        id: UUID(),
+        id: id,
         configuration: alarmConfiguration
       )
-      storeButtonTints(alarmId: alarm.id.uuidString, stop: stopConfig)
       result(alarm.id.uuidString)
     } catch {
+      removeAlarmPersistence(id.uuidString)
       result(FlutterError(
         code: "SCHEDULE_ERROR",
         message: "Failed to schedule alarm: \(error.localizedDescription)",
@@ -607,20 +655,29 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
         sound: resolveSoundAsset(soundPath),
       )
 
+    let id = UUID()
+    storeAlarmMeta(
+      alarmId: id.uuidString,
+      label: label,
+      tintColorHex: hexString(from: tintColor),
+      createdAt: Date().timeIntervalSince1970
+    )
+    storeButtonTints(
+      alarmId: id.uuidString,
+      stop: stopConfig,
+      pause: pauseConfig,
+      resume: resumeConfig,
+      repeatButton: repeatConfig
+    )
+
     do {
       let alarm = try await manager.schedule(
-        id: UUID(),
+        id: id,
         configuration: alarmConfiguration
-      )
-      storeButtonTints(
-        alarmId: alarm.id.uuidString,
-        stop: stopConfig,
-        pause: pauseConfig,
-        resume: resumeConfig,
-        repeatButton: repeatConfig
       )
       result(alarm.id.uuidString)
     } catch {
+      removeAlarmPersistence(id.uuidString)
       result(FlutterError(
         code: "SCHEDULE_ERROR",
         message: "Failed to schedule countdown alarm: \(error.localizedDescription)",
@@ -727,13 +784,22 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
         sound: resolveSoundAsset(soundPath),
       )
 
+    let id = UUID()
+    storeAlarmMeta(
+      alarmId: id.uuidString,
+      label: label,
+      tintColorHex: hexString(from: tintColor),
+      createdAt: Date().timeIntervalSince1970
+    )
+    storeButtonTints(alarmId: id.uuidString, stop: stopConfig)
+
     do {
       let alarm = try await manager.schedule(
-        id: UUID(), configuration: config
+        id: id, configuration: config
       )
-      storeButtonTints(alarmId: alarm.id.uuidString, stop: stopConfig)
       result(alarm.id.uuidString)
     } catch {
+      removeAlarmPersistence(id.uuidString)
       result(FlutterError(
         code: "SCHEDULE_ERROR",
         message: "Failed to schedule recurrent alarm: \(error.localizedDescription)",
@@ -746,7 +812,8 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     let manager = AlarmManager.shared
     do {
         let alarms = try manager.alarms
-        let alarmsData = alarms.compactMap { $0.toDictionary() }
+        let alarmsData = alarms.map { $0.toDictionary() }
+        pruneOrphanedPersistence(liveIds: Set(alarms.map { $0.id.uuidString }))
         result(alarmsData)
     } catch {
         result(FlutterError(
@@ -754,6 +821,28 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
             message: "Failed to get alarms: \(error.localizedDescription)",
             details: nil
         ))
+    }
+  }
+
+  /// Delete persisted App Group state for alarms that no longer exist. Guarded
+  /// by a grace period on the stored `createdAt` so a concurrent in-flight
+  /// schedule (persisted but not yet visible in `manager.alarms`) isn't pruned.
+  private func pruneOrphanedPersistence(liveIds: Set<String>) {
+    guard let defaults = UserDefaults(suiteName: AlarmkitPluginImpl.appGroupId) else { return }
+    let graceSeconds: TimeInterval = 60
+    let now = Date().timeIntervalSince1970
+    for (key, value) in defaults.dictionaryRepresentation() {
+      guard key.hasPrefix("alarm_meta_") else { continue }
+      let alarmId = String(key.dropFirst("alarm_meta_".count))
+      if liveIds.contains(alarmId) { continue }
+      // Keep entries still inside the grace window (covers in-flight schedules
+      // and metadata written without a createdAt by older plugin versions).
+      if let meta = value as? [String: Any],
+         let createdAt = meta["createdAt"] as? TimeInterval,
+         now - createdAt <= graceSeconds {
+        continue
+      }
+      removeAlarmPersistence(alarmId)
     }
   }
 
@@ -770,6 +859,7 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
 
     do {
       try manager.cancel(id: parsed.uuid)
+      removeAlarmPersistence(parsed.alarmId)
       result(true)
     } catch {
       result(FlutterError(

--- a/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
+++ b/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
@@ -831,13 +831,25 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     guard let defaults = UserDefaults(suiteName: AlarmkitPluginImpl.appGroupId) else { return }
     let graceSeconds: TimeInterval = 60
     let now = Date().timeIntervalSince1970
-    for (key, value) in defaults.dictionaryRepresentation() {
-      guard key.hasPrefix("alarm_meta_") else { continue }
-      let alarmId = String(key.dropFirst("alarm_meta_".count))
+    let all = defaults.dictionaryRepresentation()
+
+    // Collect candidate ids from both metadata and tint keys, so legacy
+    // `alarm_tints_*` entries written before metadata existed are also pruned.
+    var candidateIds = Set<String>()
+    for key in all.keys {
+      if key.hasPrefix("alarm_meta_") {
+        candidateIds.insert(String(key.dropFirst("alarm_meta_".count)))
+      } else if key.hasPrefix("alarm_tints_") {
+        candidateIds.insert(String(key.dropFirst("alarm_tints_".count)))
+      }
+    }
+
+    for alarmId in candidateIds {
       if liveIds.contains(alarmId) { continue }
-      // Keep entries still inside the grace window (covers in-flight schedules
-      // and metadata written without a createdAt by older plugin versions).
-      if let meta = value as? [String: Any],
+      // Keep entries still inside the grace window (covers in-flight schedules).
+      // Schedules always write metadata before tints, so a tints-only entry can
+      // only be a legacy alarm with no createdAt — safe to prune once orphaned.
+      if let meta = all["alarm_meta_\(alarmId)"] as? [String: Any],
          let createdAt = meta["createdAt"] as? TimeInterval,
          now - createdAt <= graceSeconds {
         continue

--- a/lib/flutter_alarmkit.dart
+++ b/lib/flutter_alarmkit.dart
@@ -2,11 +2,23 @@ import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_alarmkit/flutter_alarmkit_method_channel.dart';
 
 import 'package:flutter_alarmkit/flutter_alarmkit_platform_interface.dart';
+import 'package:flutter_alarmkit/src/alarm.dart';
 import 'package:flutter_alarmkit/src/alarm_ui_config.dart';
+import 'package:flutter_alarmkit/src/alarm_update_event.dart';
 import 'package:flutter_alarmkit/src/weekday.dart' show Weekday;
 
+export 'src/alarm.dart'
+    show
+        Alarm,
+        AlarmCountdownDuration,
+        AlarmSchedule,
+        AlarmState,
+        FixedAlarmSchedule,
+        RelativeAlarmSchedule,
+        UnknownAlarmSchedule;
 export 'src/alarm_button_config.dart' show AlarmButtonConfig;
 export 'src/alarm_ui_config.dart' show AlarmUIConfig;
+export 'src/alarm_update_event.dart' show AlarmUpdateEvent, AlarmUpdateKind;
 export 'src/weekday.dart' show Weekday;
 
 /// A plugin for scheduling alarms using AlarmKit on iOS.
@@ -55,14 +67,13 @@ class FlutterAlarmkit {
 
   /// A stream of alarm updates.
   ///
-  /// This stream emits events when alarms are added, updated, or removed.
-  ///
-  /// Returns a [Stream<dynamic>] that emits events when alarms are added,
-  /// updated, or removed.
+  /// Emits an [AlarmUpdateEvent] whenever an alarm is added, updated, or
+  /// removed. `updated` events fire only when an alarm's state, schedule, or
+  /// countdown duration actually changes.
   ///
   /// Throws a [PlatformException] if the platform version is not supported
   /// (iOS < 26.0)
-  Stream<dynamic> alarmUpdates() {
+  Stream<AlarmUpdateEvent> alarmUpdates() {
     return FlutterAlarmkitPlatform.instance.alarmUpdates();
   }
 
@@ -245,14 +256,15 @@ class FlutterAlarmkit {
     );
   }
 
-  /// Gets all the alarms scheduled in the system.
+  /// Gets all the alarms currently known to the system.
   ///
-  /// Returns a [Future<List<Map<String, dynamic>>>] that completes with a
-  /// list of alarms.
+  /// Returns a [Future] that completes with the list of [Alarm]s, including
+  /// each alarm's [AlarmState], schedule, and (for alarms scheduled through
+  /// this plugin) its persisted label and tint color.
   ///
   /// Throws a [PlatformException] if the platform version is not supported
   /// (iOS < 26.0)
-  Future<List<Map<String, dynamic>>> getAlarms() {
+  Future<List<Alarm>> getAlarms() {
     return FlutterAlarmkitPlatform.instance.getAlarms();
   }
 

--- a/lib/flutter_alarmkit_method_channel.dart
+++ b/lib/flutter_alarmkit_method_channel.dart
@@ -2,6 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_alarmkit/flutter_alarmkit_platform_interface.dart';
+import 'package:flutter_alarmkit/src/alarm.dart';
+import 'package:flutter_alarmkit/src/alarm_update_event.dart';
 
 /// An implementation of [FlutterAlarmkitPlatform] that uses method channels.
 class MethodChannelFlutterAlarmkit extends FlutterAlarmkitPlatform {
@@ -10,11 +12,15 @@ class MethodChannelFlutterAlarmkit extends FlutterAlarmkitPlatform {
   final methodChannel = const MethodChannel('flutter_alarmkit');
 
   static const _eventChannel = EventChannel('flutter_alarmkit/events');
-  Stream<dynamic>? _alarmUpdates;
+  Stream<AlarmUpdateEvent>? _alarmUpdates;
 
   @override
-  Stream<dynamic> alarmUpdates() {
-    _alarmUpdates ??= _eventChannel.receiveBroadcastStream();
+  Stream<AlarmUpdateEvent> alarmUpdates() {
+    _alarmUpdates ??= _eventChannel.receiveBroadcastStream().map(
+      (dynamic event) => AlarmUpdateEvent.fromMap(
+        (event as Map).map((key, dynamic v) => MapEntry(key.toString(), v)),
+      ),
+    );
     return _alarmUpdates!;
   }
 
@@ -173,11 +179,14 @@ class MethodChannelFlutterAlarmkit extends FlutterAlarmkitPlatform {
   }
 
   @override
-  Future<List<Map<String, dynamic>>> getAlarms() async {
+  Future<List<Alarm>> getAlarms() async {
     final alarms = await methodChannel.invokeListMethod<Map<dynamic, dynamic>>(
       'getAlarms',
     );
-    return alarms?.map((alarm) => alarm.cast<String, dynamic>()).toList() ?? [];
+    return alarms
+            ?.map((alarm) => Alarm.fromMap(alarm.cast<String, dynamic>()))
+            .toList() ??
+        [];
   }
 
   @override

--- a/lib/flutter_alarmkit_platform_interface.dart
+++ b/lib/flutter_alarmkit_platform_interface.dart
@@ -1,6 +1,8 @@
 // ignore_for_file: public_member_api_docs, document_ignores
 
 import 'package:flutter_alarmkit/flutter_alarmkit_method_channel.dart';
+import 'package:flutter_alarmkit/src/alarm.dart';
+import 'package:flutter_alarmkit/src/alarm_update_event.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 /// A plugin for scheduling alarms using AlarmKit on iOS.
@@ -78,7 +80,7 @@ abstract class FlutterAlarmkitPlatform extends PlatformInterface {
     );
   }
 
-  Future<List<Map<String, dynamic>>> getAlarms() {
+  Future<List<Alarm>> getAlarms() {
     throw UnimplementedError('getAlarms() has not been implemented.');
   }
 
@@ -102,7 +104,7 @@ abstract class FlutterAlarmkitPlatform extends PlatformInterface {
     throw UnimplementedError('resumeAlarm() has not been implemented.');
   }
 
-  Stream<dynamic> alarmUpdates() {
+  Stream<AlarmUpdateEvent> alarmUpdates() {
     throw UnimplementedError('alarmUpdates() has not been implemented.');
   }
 }

--- a/lib/src/alarm.dart
+++ b/lib/src/alarm.dart
@@ -86,15 +86,19 @@ class RelativeAlarmSchedule extends AlarmSchedule {
   /// Minute of hour, 0–59.
   final int minute;
 
-  /// The weekdays the alarm repeats on. Empty means it does not repeat.
+  /// The weekdays the alarm repeats on (unmodifiable). Empty means it does not
+  /// repeat.
   final Set<Weekday> weekdays;
 
   /// Creates a relative schedule firing at [hour]:[minute] on [weekdays].
-  const RelativeAlarmSchedule({
+  ///
+  /// [weekdays] is copied into an unmodifiable set so the schedule stays
+  /// immutable — its value equality and hash code depend on it.
+  RelativeAlarmSchedule({
     required this.hour,
     required this.minute,
-    this.weekdays = const {},
-  });
+    Set<Weekday> weekdays = const {},
+  }) : weekdays = Set.unmodifiable(weekdays);
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/alarm.dart
+++ b/lib/src/alarm.dart
@@ -1,0 +1,282 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_alarmkit/src/weekday.dart';
+
+/// The lifecycle state of an alarm, mirroring AlarmKit's `Alarm.State`.
+enum AlarmState {
+  /// The alarm is scheduled and waiting for its fire date.
+  scheduled,
+
+  /// The alarm is a countdown timer that is currently running.
+  countdown,
+
+  /// A countdown alarm whose timer has been paused.
+  paused,
+
+  /// The alarm is currently firing (ringing / presenting its alert).
+  alerting,
+
+  /// The state could not be mapped — e.g. a future AlarmKit state this
+  /// version of the plugin does not yet know about.
+  unknown;
+
+  /// Maps a raw state string from the platform channel to an [AlarmState].
+  ///
+  /// Unrecognized or null values map to [AlarmState.unknown] so the API stays
+  /// forward-compatible with future iOS releases.
+  static AlarmState fromRaw(String? raw) {
+    switch (raw) {
+      case 'scheduled':
+        return AlarmState.scheduled;
+      case 'countdown':
+        return AlarmState.countdown;
+      case 'paused':
+        return AlarmState.paused;
+      case 'alerting':
+        return AlarmState.alerting;
+      default:
+        return AlarmState.unknown;
+    }
+  }
+}
+
+/// When an alarm is set to fire.
+///
+/// This is a sealed hierarchy: an [AlarmSchedule] is exactly one of
+/// [FixedAlarmSchedule], [RelativeAlarmSchedule], or [UnknownAlarmSchedule],
+/// so callers can exhaustively `switch` over it. Countdown timers have no
+/// schedule at all — their [Alarm.schedule] is null and the timing lives in
+/// [Alarm.countdownDuration] instead.
+@immutable
+sealed class AlarmSchedule {
+  /// Const constructor for subclasses.
+  const AlarmSchedule();
+}
+
+/// A one-shot alarm that fires at a fixed wall-clock [date].
+@immutable
+class FixedAlarmSchedule extends AlarmSchedule {
+  /// The exact moment the alarm fires.
+  final DateTime date;
+
+  /// Creates a fixed schedule firing at [date].
+  const FixedAlarmSchedule(this.date);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FixedAlarmSchedule && other.date == date;
+
+  @override
+  int get hashCode => date.hashCode;
+
+  @override
+  String toString() => 'FixedAlarmSchedule(date: $date)';
+}
+
+/// A recurring alarm that fires at [hour]:[minute] on the given [weekdays].
+///
+/// An empty [weekdays] set represents an alarm that fires once at the next
+/// occurrence of [hour]:[minute] without repeating (AlarmKit's `.never`
+/// recurrence).
+@immutable
+class RelativeAlarmSchedule extends AlarmSchedule {
+  /// Hour of day, 0–23.
+  final int hour;
+
+  /// Minute of hour, 0–59.
+  final int minute;
+
+  /// The weekdays the alarm repeats on. Empty means it does not repeat.
+  final Set<Weekday> weekdays;
+
+  /// Creates a relative schedule firing at [hour]:[minute] on [weekdays].
+  const RelativeAlarmSchedule({
+    required this.hour,
+    required this.minute,
+    this.weekdays = const {},
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RelativeAlarmSchedule &&
+          other.hour == hour &&
+          other.minute == minute &&
+          setEquals(other.weekdays, weekdays);
+
+  @override
+  int get hashCode => Object.hash(hour, minute, Object.hashAllUnordered(weekdays));
+
+  @override
+  String toString() =>
+      'RelativeAlarmSchedule(hour: $hour, minute: $minute, weekdays: $weekdays)';
+}
+
+/// A schedule of a kind this version of the plugin does not recognize.
+///
+/// Emitted instead of dropping the alarm when the platform reports a schedule
+/// type added in a newer iOS release.
+@immutable
+class UnknownAlarmSchedule extends AlarmSchedule {
+  /// Creates an unknown schedule marker.
+  const UnknownAlarmSchedule();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is UnknownAlarmSchedule;
+
+  @override
+  int get hashCode => (UnknownAlarmSchedule).hashCode;
+
+  @override
+  String toString() => 'UnknownAlarmSchedule()';
+}
+
+/// The countdown timing of a countdown alarm, mirroring AlarmKit's
+/// `Alarm.CountdownDuration`.
+@immutable
+class AlarmCountdownDuration {
+  /// Seconds to count down before the alarm fires, if set.
+  final double? preAlert;
+
+  /// Seconds to count down after the alarm fires (e.g. the snooze phase),
+  /// if set.
+  final double? postAlert;
+
+  /// Creates a countdown duration with optional [preAlert]/[postAlert] seconds.
+  const AlarmCountdownDuration({this.preAlert, this.postAlert});
+
+  /// Builds an [AlarmCountdownDuration] from a platform-channel map.
+  factory AlarmCountdownDuration.fromMap(Map<String, dynamic> map) {
+    return AlarmCountdownDuration(
+      preAlert: (map['preAlert'] as num?)?.toDouble(),
+      postAlert: (map['postAlert'] as num?)?.toDouble(),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AlarmCountdownDuration &&
+          other.preAlert == preAlert &&
+          other.postAlert == postAlert;
+
+  @override
+  int get hashCode => Object.hash(preAlert, postAlert);
+
+  @override
+  String toString() =>
+      'AlarmCountdownDuration(preAlert: $preAlert, postAlert: $postAlert)';
+}
+
+/// A snapshot of an alarm known to the system, as returned by
+/// `FlutterAlarmkit.getAlarms()` and carried by alarm-update events.
+///
+/// Note that [label] and [tintColor] are persisted by the plugin (AlarmKit
+/// does not expose an alarm's presentation back to the app) and are only
+/// available for alarms scheduled through this plugin.
+@immutable
+class Alarm {
+  /// The alarm's unique identifier (a UUID string).
+  final String id;
+
+  /// The current lifecycle state of the alarm.
+  final AlarmState state;
+
+  /// When the alarm fires, or null for a countdown timer (see
+  /// [countdownDuration]).
+  final AlarmSchedule? schedule;
+
+  /// The countdown timing, present only for countdown alarms.
+  final AlarmCountdownDuration? countdownDuration;
+
+  /// The title shown in the alarm presentation, if the plugin persisted one.
+  final String? label;
+
+  /// The alarm's tint color as a `#RRGGBB` hex string, if the plugin
+  /// persisted one.
+  final String? tintColor;
+
+  /// Creates an [Alarm] snapshot.
+  const Alarm({
+    required this.id,
+    required this.state,
+    this.schedule,
+    this.countdownDuration,
+    this.label,
+    this.tintColor,
+  });
+
+  /// Builds an [Alarm] from a platform-channel map.
+  ///
+  /// Tolerant of the `Map<Object?, Object?>` shape that platform channels
+  /// produce for nested maps.
+  factory Alarm.fromMap(Map<String, dynamic> map) {
+    return Alarm(
+      id: map['id'] as String,
+      state: AlarmState.fromRaw(map['state'] as String?),
+      schedule: _scheduleFromMap(_asStringMap(map['schedule'])),
+      countdownDuration: () {
+        final cd = _asStringMap(map['countdownDuration']);
+        return cd == null ? null : AlarmCountdownDuration.fromMap(cd);
+      }(),
+      label: map['label'] as String?,
+      tintColor: map['tintColor'] as String?,
+    );
+  }
+
+  static AlarmSchedule? _scheduleFromMap(Map<String, dynamic>? map) {
+    if (map == null) return null;
+    switch (map['type'] as String?) {
+      case 'fixed':
+        final ms = (map['timestamp'] as num).round();
+        return FixedAlarmSchedule(DateTime.fromMillisecondsSinceEpoch(ms));
+      case 'relative':
+        return RelativeAlarmSchedule(
+          hour: (map['hour'] as num).toInt(),
+          minute: (map['minute'] as num).toInt(),
+          weekdays: _weekdaysFromMask((map['weekdayMask'] as num?)?.toInt() ?? 0),
+        );
+      default:
+        return const UnknownAlarmSchedule();
+    }
+  }
+
+  static Set<Weekday> _weekdaysFromMask(int mask) {
+    return {
+      for (final day in Weekday.values)
+        if (mask & (1 << day.index) != 0) day,
+    };
+  }
+
+  /// Normalizes a dynamic channel value into a `Map<String, dynamic>`,
+  /// accepting the `Map<Object?, Object?>` that nested channel maps decode to.
+  static Map<String, dynamic>? _asStringMap(Object? value) {
+    if (value is Map) {
+      return value.map(
+        (key, dynamic v) => MapEntry(key.toString(), v),
+      );
+    }
+    return null;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Alarm &&
+          other.id == id &&
+          other.state == state &&
+          other.schedule == schedule &&
+          other.countdownDuration == countdownDuration &&
+          other.label == label &&
+          other.tintColor == tintColor;
+
+  @override
+  int get hashCode =>
+      Object.hash(id, state, schedule, countdownDuration, label, tintColor);
+
+  @override
+  String toString() => 'Alarm(id: $id, state: $state, schedule: $schedule, '
+      'countdownDuration: $countdownDuration, label: $label, '
+      'tintColor: $tintColor)';
+}

--- a/lib/src/alarm_update_event.dart
+++ b/lib/src/alarm_update_event.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_alarmkit/src/alarm.dart';
+
+/// The kind of change carried by an [AlarmUpdateEvent].
+enum AlarmUpdateKind {
+  /// An alarm was added (scheduled).
+  added,
+
+  /// An existing alarm changed (state, schedule, or countdown duration).
+  updated,
+
+  /// An alarm was removed (cancelled, stopped, or completed).
+  removed,
+
+  /// An event kind this version of the plugin does not recognize.
+  unknown;
+
+  /// Maps a raw event string from the platform channel to an
+  /// [AlarmUpdateKind]. Unrecognized values map to [AlarmUpdateKind.unknown].
+  static AlarmUpdateKind fromRaw(String? raw) {
+    switch (raw) {
+      case 'add':
+        return AlarmUpdateKind.added;
+      case 'update':
+        return AlarmUpdateKind.updated;
+      case 'remove':
+        return AlarmUpdateKind.removed;
+      default:
+        return AlarmUpdateKind.unknown;
+    }
+  }
+}
+
+/// An event emitted by `FlutterAlarmkit.alarmUpdates()` whenever an alarm is
+/// added, updated, or removed.
+@immutable
+class AlarmUpdateEvent {
+  /// What changed.
+  final AlarmUpdateKind kind;
+
+  /// The id of the affected alarm.
+  final String alarmId;
+
+  /// The alarm snapshot. Non-null for [AlarmUpdateKind.added] and
+  /// [AlarmUpdateKind.updated]; null for [AlarmUpdateKind.removed] (and
+  /// usually for [AlarmUpdateKind.unknown]).
+  final Alarm? alarm;
+
+  /// Creates an [AlarmUpdateEvent].
+  const AlarmUpdateEvent({
+    required this.kind,
+    required this.alarmId,
+    this.alarm,
+  });
+
+  /// Builds an [AlarmUpdateEvent] from a platform-channel map.
+  ///
+  /// Tolerant of the `Map<Object?, Object?>` shape that platform channels
+  /// produce for nested maps.
+  factory AlarmUpdateEvent.fromMap(Map<String, dynamic> map) {
+    final rawAlarm = map['alarm'];
+    return AlarmUpdateEvent(
+      kind: AlarmUpdateKind.fromRaw(map['event'] as String?),
+      alarmId: map['id'] as String,
+      alarm: rawAlarm is Map
+          ? Alarm.fromMap(
+              rawAlarm.map((key, dynamic v) => MapEntry(key.toString(), v)),
+            )
+          : null,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AlarmUpdateEvent &&
+          other.kind == kind &&
+          other.alarmId == alarmId &&
+          other.alarm == alarm;
+
+  @override
+  int get hashCode => Object.hash(kind, alarmId, alarm);
+
+  @override
+  String toString() =>
+      'AlarmUpdateEvent(kind: $kind, alarmId: $alarmId, alarm: $alarm)';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_alarmkit
 description: "Flutter plugin for Apple AlarmKit (iOS 26+). Schedule one-shot, countdown, and recurring alarms as Lock Screen and Dynamic Island Live Activities."
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/gdelataillade/flutter_alarmkit
 
 environment:

--- a/test/alarm_test.dart
+++ b/test/alarm_test.dart
@@ -140,12 +140,12 @@ void main() {
 
   group('equality and hashing', () {
     test('weekday set equality is order-independent', () {
-      const a = RelativeAlarmSchedule(
+      final a = RelativeAlarmSchedule(
         hour: 7,
         minute: 0,
         weekdays: {Weekday.monday, Weekday.friday},
       );
-      const b = RelativeAlarmSchedule(
+      final b = RelativeAlarmSchedule(
         hour: 7,
         minute: 0,
         weekdays: {Weekday.friday, Weekday.monday},
@@ -153,6 +153,25 @@ void main() {
 
       expect(a, b);
       expect(a.hashCode, b.hashCode);
+    });
+
+    test('weekdays is unmodifiable and decoupled from the source set', () {
+      final source = {Weekday.monday};
+      final schedule = RelativeAlarmSchedule(
+        hour: 6,
+        minute: 0,
+        weekdays: source,
+      );
+
+      // Mutating the source after construction must not affect the schedule.
+      source.add(Weekday.tuesday);
+      expect(schedule.weekdays, {Weekday.monday});
+
+      // The stored set itself must reject mutation.
+      expect(
+        () => schedule.weekdays.add(Weekday.sunday),
+        throwsUnsupportedError,
+      );
     });
 
     test('Alarm value equality covers all fields', () {

--- a/test/alarm_test.dart
+++ b/test/alarm_test.dart
@@ -1,0 +1,178 @@
+// Test fixtures pass plain map literals to the model factories; const-ness is
+// irrelevant here.
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
+import 'package:flutter_alarmkit/flutter_alarmkit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AlarmState.fromRaw', () {
+    test('maps every known state', () {
+      expect(AlarmState.fromRaw('scheduled'), AlarmState.scheduled);
+      expect(AlarmState.fromRaw('countdown'), AlarmState.countdown);
+      expect(AlarmState.fromRaw('paused'), AlarmState.paused);
+      expect(AlarmState.fromRaw('alerting'), AlarmState.alerting);
+    });
+
+    test('maps unknown and null to unknown', () {
+      expect(AlarmState.fromRaw('a-future-state'), AlarmState.unknown);
+      expect(AlarmState.fromRaw(null), AlarmState.unknown);
+    });
+  });
+
+  group('Alarm.fromMap schedules', () {
+    test('fixed schedule preserves the timestamp', () {
+      final alarm = Alarm.fromMap({
+        'id': 'A',
+        'state': 'scheduled',
+        'schedule': {'type': 'fixed', 'timestamp': 1718000000000.0},
+      });
+
+      expect(alarm.schedule, isA<FixedAlarmSchedule>());
+      final schedule = alarm.schedule! as FixedAlarmSchedule;
+      expect(schedule.date.millisecondsSinceEpoch, 1718000000000);
+    });
+
+    test('relative schedule round-trips the weekday mask', () {
+      final mask = Weekday.toBitmask(
+        {Weekday.monday, Weekday.friday, Weekday.sunday},
+      );
+      final alarm = Alarm.fromMap({
+        'id': 'A',
+        'state': 'scheduled',
+        'schedule': {
+          'type': 'relative',
+          'hour': 7,
+          'minute': 30,
+          'weekdayMask': mask,
+        },
+      });
+
+      expect(alarm.schedule, isA<RelativeAlarmSchedule>());
+      final schedule = alarm.schedule! as RelativeAlarmSchedule;
+      expect(schedule.hour, 7);
+      expect(schedule.minute, 30);
+      expect(
+        schedule.weekdays,
+        {Weekday.monday, Weekday.friday, Weekday.sunday},
+      );
+    });
+
+    test('relative schedule with empty mask has no weekdays', () {
+      final alarm = Alarm.fromMap({
+        'id': 'A',
+        'state': 'scheduled',
+        'schedule': {'type': 'relative', 'hour': 8, 'minute': 0, 'weekdayMask': 0},
+      });
+
+      final schedule = alarm.schedule! as RelativeAlarmSchedule;
+      expect(schedule.weekdays, isEmpty);
+    });
+
+    test('countdown alarm has no schedule and nullable durations', () {
+      final alarm = Alarm.fromMap({
+        'id': 'A',
+        'state': 'countdown',
+        'countdownDuration': {'preAlert': 60.0},
+      });
+
+      expect(alarm.schedule, isNull);
+      expect(alarm.countdownDuration, isNotNull);
+      expect(alarm.countdownDuration!.preAlert, 60.0);
+      expect(alarm.countdownDuration!.postAlert, isNull);
+    });
+
+    test('unknown schedule type is retained, not dropped', () {
+      final alarm = Alarm.fromMap({
+        'id': 'A',
+        'state': 'scheduled',
+        'schedule': {'type': 'a-future-kind'},
+      });
+
+      expect(alarm.schedule, isA<UnknownAlarmSchedule>());
+    });
+  });
+
+  group('Alarm.fromMap nested channel maps', () {
+    test('accepts Map<Object?, Object?> nested maps from the channel', () {
+      final raw = <Object?, Object?>{
+        'id': 'A',
+        'state': 'scheduled',
+        'schedule': <Object?, Object?>{
+          'type': 'relative',
+          'hour': 9,
+          'minute': 0,
+          'weekdayMask': 1, // monday
+        },
+        'countdownDuration': <Object?, Object?>{'preAlert': 30.0, 'postAlert': 5.0},
+      };
+
+      final alarm = Alarm.fromMap(raw.cast<String, dynamic>());
+
+      expect(alarm.schedule, isA<RelativeAlarmSchedule>());
+      final schedule = alarm.schedule! as RelativeAlarmSchedule;
+      expect(schedule.hour, 9);
+      expect(schedule.weekdays, {Weekday.monday});
+      expect(alarm.countdownDuration!.postAlert, 5.0);
+    });
+  });
+
+  group('Alarm metadata', () {
+    test('parses persisted label and tint color', () {
+      final alarm = Alarm.fromMap({
+        'id': 'A',
+        'state': 'scheduled',
+        'label': 'Wake up',
+        'tintColor': '#FF0000',
+      });
+
+      expect(alarm.label, 'Wake up');
+      expect(alarm.tintColor, '#FF0000');
+    });
+
+    test('leaves label and tint null when absent', () {
+      final alarm = Alarm.fromMap({'id': 'A', 'state': 'scheduled'});
+
+      expect(alarm.label, isNull);
+      expect(alarm.tintColor, isNull);
+    });
+  });
+
+  group('equality and hashing', () {
+    test('weekday set equality is order-independent', () {
+      const a = RelativeAlarmSchedule(
+        hour: 7,
+        minute: 0,
+        weekdays: {Weekday.monday, Weekday.friday},
+      );
+      const b = RelativeAlarmSchedule(
+        hour: 7,
+        minute: 0,
+        weekdays: {Weekday.friday, Weekday.monday},
+      );
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('Alarm value equality covers all fields', () {
+      Alarm build() => Alarm.fromMap({
+            'id': 'A',
+            'state': 'countdown',
+            'countdownDuration': {'preAlert': 30.0, 'postAlert': 5.0},
+            'label': 'x',
+            'tintColor': '#112233',
+          });
+
+      expect(build(), build());
+      expect(build().hashCode, build().hashCode);
+    });
+
+    test('Alarms differing in state are not equal', () {
+      final scheduled = Alarm.fromMap({'id': 'A', 'state': 'scheduled'});
+      final alerting = Alarm.fromMap({'id': 'A', 'state': 'alerting'});
+
+      expect(scheduled, isNot(alerting));
+    });
+  });
+}

--- a/test/alarm_update_event_test.dart
+++ b/test/alarm_update_event_test.dart
@@ -1,0 +1,66 @@
+// Test fixtures pass plain map literals to the model factories; const-ness is
+// irrelevant here.
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
+import 'package:flutter_alarmkit/flutter_alarmkit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('add event carries a typed alarm', () {
+    final event = AlarmUpdateEvent.fromMap({
+      'id': 'A',
+      'event': 'add',
+      'alarm': {'id': 'A', 'state': 'scheduled'},
+    });
+
+    expect(event.kind, AlarmUpdateKind.added);
+    expect(event.alarmId, 'A');
+    expect(event.alarm, isNotNull);
+    expect(event.alarm!.state, AlarmState.scheduled);
+  });
+
+  test('update event carries the new alarm state', () {
+    final event = AlarmUpdateEvent.fromMap({
+      'id': 'A',
+      'event': 'update',
+      'alarm': {'id': 'A', 'state': 'countdown'},
+    });
+
+    expect(event.kind, AlarmUpdateKind.updated);
+    expect(event.alarm!.state, AlarmState.countdown);
+  });
+
+  test('remove event has a null alarm', () {
+    final event = AlarmUpdateEvent.fromMap({'id': 'A', 'event': 'remove'});
+
+    expect(event.kind, AlarmUpdateKind.removed);
+    expect(event.alarmId, 'A');
+    expect(event.alarm, isNull);
+  });
+
+  test('unrecognized event kind maps to unknown', () {
+    final event = AlarmUpdateEvent.fromMap({'id': 'A', 'event': 'whoknows'});
+
+    expect(event.kind, AlarmUpdateKind.unknown);
+  });
+
+  test('decodes nested Map<Object?, Object?> alarm payloads', () {
+    final raw = <Object?, Object?>{
+      'id': 'A',
+      'event': 'add',
+      'alarm': <Object?, Object?>{
+        'id': 'A',
+        'state': 'scheduled',
+        'schedule': <Object?, Object?>{
+          'type': 'fixed',
+          'timestamp': 1718000000000.0,
+        },
+      },
+    };
+
+    final event = AlarmUpdateEvent.fromMap(raw.cast<String, dynamic>());
+
+    expect(event.kind, AlarmUpdateKind.added);
+    expect(event.alarm!.schedule, isA<FixedAlarmSchedule>());
+  });
+}

--- a/test/flutter_alarmkit_method_channel_test.dart
+++ b/test/flutter_alarmkit_method_channel_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_alarmkit/flutter_alarmkit.dart';
+import 'package:flutter_alarmkit/flutter_alarmkit_method_channel.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('flutter_alarmkit');
+  final platform = MethodChannelFlutterAlarmkit();
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('getAlarms decodes channel maps into typed Alarms', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method != 'getAlarms') return null;
+      // Mirror the StandardMessageCodec shapes a real iOS reply produces:
+      // a List<Object?> of Map<Object?, Object?> with nested maps.
+      return <Object?>[
+        <Object?, Object?>{
+          'id': 'A',
+          'state': 'alerting',
+          'schedule': <Object?, Object?>{
+            'type': 'fixed',
+            'timestamp': 1718000000000.0,
+          },
+          'label': 'Wake',
+          'tintColor': '#00FF00',
+        },
+        <Object?, Object?>{
+          'id': 'B',
+          'state': 'countdown',
+          'countdownDuration': <Object?, Object?>{
+            'preAlert': 60.0,
+            'postAlert': 5.0,
+          },
+        },
+      ];
+    });
+
+    final alarms = await platform.getAlarms();
+
+    expect(alarms, hasLength(2));
+
+    expect(alarms[0].id, 'A');
+    expect(alarms[0].state, AlarmState.alerting);
+    expect(alarms[0].schedule, isA<FixedAlarmSchedule>());
+    expect(alarms[0].label, 'Wake');
+    expect(alarms[0].tintColor, '#00FF00');
+
+    expect(alarms[1].id, 'B');
+    expect(alarms[1].state, AlarmState.countdown);
+    expect(alarms[1].schedule, isNull);
+    expect(alarms[1].countdownDuration!.preAlert, 60.0);
+    expect(alarms[1].countdownDuration!.postAlert, 5.0);
+  });
+
+  test('getAlarms returns an empty list when the platform returns null',
+      () async {
+    messenger.setMockMethodCallHandler(channel, (call) async => null);
+
+    expect(await platform.getAlarms(), isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary

Makes reading alarms back as capable as scheduling them. Closes the two highest-value gaps in the read path:

- **Full state reporting (bug fix).** `toDictionary()` only mapped `scheduled`/`paused`; AlarmKit's `countdown` and **`alerting`** fell through to `"unknown"`, and an unrecognized *schedule* returned `nil` — silently **dropping the alarm** from `getAlarms()`. Now every `Alarm.State` is mapped, and `toDictionary()` is non-nullable (unknown state/schedule surfaces as `unknown`, never dropped).
- **Typed, richer model.** `getAlarms()` → `Future<List<Alarm>>` and `alarmUpdates()` → `Stream<AlarmUpdateEvent>`, exposing each alarm's state, schedule (incl. recurrence weekdays), countdown durations, and persisted label/tint.

## API (BREAKING — bumps to 0.3.0)

| Before | After |
|---|---|
| `getAlarms() → Future<List<Map<String,dynamic>>>` | `getAlarms() → Future<List<Alarm>>` |
| `alarmUpdates() → Stream<dynamic>` | `alarmUpdates() → Stream<AlarmUpdateEvent>` |

New exported types: `Alarm`, `AlarmState`, sealed `AlarmSchedule` (`Fixed`/`Relative`/`Unknown`), `AlarmCountdownDuration`, `AlarmUpdateEvent`, `AlarmUpdateKind`.

## Notes

- AlarmKit doesn't expose an alarm's presentation back to the app, so **label/tint are persisted by the plugin** in the App Group — written *before* scheduling (so the initial `add` event carries them), rolled back on failure, and cleaned up on cancel/removal with grace-guarded orphan pruning.
- `alarmUpdates()` now emits `update` only on genuine state/schedule/countdown changes (was firing for every alarm on every snapshot).
- Example app gains a live alarm list with per-state colors, driven by `getAlarms()` + `alarmUpdates()`.

## Test plan

- `flutter analyze` clean (root + example); new root `test/` (20 tests) covers model decoding, weekday round-trip, unknown states/schedules, nullable countdown fields, and nested channel maps — all green.
- Manual on-device (iOS 26) verification pending: schedule one-shot/countdown/recurrent, watch `scheduled → countdown → alerting` transitions, confirm labels/weekdays/tints and orphan-free cancel cycles.
- Build-time SDK symbol confirmation on first device build: `Alarm.State.alerting`/`.countdown`, `relativeSchedule.repeats` `.weekly`/`.never`, `CountdownDuration.preAlert`/`postAlert` optionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)