### PR TITLE
Open-app button, relative scheduling, cancelAll, typed auth state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+* Add an **"Open app" secondary button** for one-shot and recurrent alarms via `AlarmUIConfig.openAppButton` — the alert shows Open + Stop, and tapping Open foregrounds the app (and stops the alarm).
+* `scheduleRecurrentAlarm` now accepts an **empty `weekdays` set** to fire once at the next occurrence of the given time without repeating, plus a new `Weekday.everyday` convenience for daily alarms.
+* Add **`cancelAll()`** to cancel every scheduled alarm in one call.
+* **Breaking:** `getAuthorizationState()` now returns a typed `AlarmAuthorizationState` enum instead of a raw `int`.
+
 ## 0.3.0
 * **Typed alarm reads.** `getAlarms()` now returns `List<Alarm>` and `alarmUpdates()` emits `AlarmUpdateEvent`s, exposing each alarm's state, schedule (including recurrence weekdays), countdown durations, and persisted label/tint color.
 * Report **all** alarm states, including `countdown` and `alerting` (previously surfaced as `unknown`). Alarms with an unrecognized state or schedule are now kept (as `unknown`) instead of being silently dropped from `getAlarms()`.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ See more: https://developer.apple.com/documentation/alarmkit
 - Request authorization to schedule alarms
 - Schedule one-shot alarms
 - Schedule countdown alarms
-- Schedule recurrent alarms
+- Schedule recurrent, daily, and one-time relative alarms
 - Read scheduled alarms with their full state, schedule, and metadata (`getAlarms`)
 - Observe typed alarm add/update/remove events (`alarmUpdates`)
+- Query the typed authorization state (`getAuthorizationState`)
 - Set custom alarm sounds
-- Customize the Live Activity UI (buttons, icons, colors, titles)
-- Cancel alarms
+- Customize the Live Activity UI (buttons, icons, colors, titles), including an "Open app" button
+- Cancel a single alarm, or all alarms at once (`cancelAll`)
 - Stop alarms
 
 ## Installation
@@ -157,6 +158,27 @@ final alarmId = await FlutterAlarmkit().scheduleRecurrentAlarm(
 );
 ```
 
+Pass `Weekday.everyday` for a daily alarm, or an **empty set** to fire once at
+the next occurrence of the given time without repeating:
+
+```dart
+// Daily at 07:00
+await FlutterAlarmkit().scheduleRecurrentAlarm(
+  weekdays: Weekday.everyday,
+  hour: 7,
+  minute: 0,
+  label: 'Wake up',
+);
+
+// Once at the next 07:00 (no repeat)
+await FlutterAlarmkit().scheduleRecurrentAlarm(
+  weekdays: const {},
+  hour: 7,
+  minute: 0,
+  label: 'One-off',
+);
+```
+
 ### Customize the Live Activity UI
 
 All schedule methods accept an optional `uiConfig` to customize the Live Activity's buttons (text, SF Symbol icon, text color, tint color) and the countdown/paused titles:
@@ -183,12 +205,30 @@ final alarmId = await FlutterAlarmkit().setCountdownAlarm(
 
 Every field is optional — anything you leave null keeps the standard AlarmKit appearance. Custom tint colors require the App Group from the installation steps.
 
+For one-shot and recurrent alarms you can add an **"Open app"** secondary button (shown next to Stop) that foregrounds your app — and stops the alarm — when tapped:
+
+```dart
+await FlutterAlarmkit().scheduleOneShotAlarm(
+  timestamp: fireDate.millisecondsSinceEpoch.toDouble(),
+  label: 'Wake up',
+  uiConfig: const AlarmUIConfig(
+    openAppButton: AlarmButtonConfig(text: 'Open', icon: 'arrow.up.forward.app'),
+  ),
+);
+```
+
 ### Cancel an Alarm
 
 To cancel an alarm:
 
 ```dart
 await FlutterAlarmkit().cancelAlarm(alarmId: alarmId);
+```
+
+Or cancel every scheduled alarm at once:
+
+```dart
+await FlutterAlarmkit().cancelAll();
 ```
 
 ### Stop an Alarm

--- a/example/ios/AlarmkitWidget/AlarmkitWidgetLiveActivity.swift
+++ b/example/ios/AlarmkitWidget/AlarmkitWidgetLiveActivity.swift
@@ -200,6 +200,11 @@ struct AlarmControls: View {
         return .blue
     }
 
+    private var openTint: Color {
+        if let hex = tints["openTint"], let c = colorFromHex(hex) { return c }
+        return .blue
+    }
+
     var body: some View {
         HStack(spacing: 6) {
             switch state.mode {
@@ -216,12 +221,23 @@ struct AlarmControls: View {
                                tint: resumeTint)
                 }
             case .alert:
-                // Countdown alarms expose a secondary "repeat" button in the
-                // alert state; restart the countdown when it's tapped.
-                if let btn = presentation.alert.secondaryButton {
-                    ButtonView(config: btn,
-                               intent: RepeatIntent(alarmID: state.alarmID.uuidString),
-                               tint: repeatTint)
+                // The alert's secondary button is either a countdown "repeat"
+                // (countdown alarms) or a custom "open app" action (one-shot /
+                // recurrent alarms) — pick the intent by its declared behavior.
+                if let btn = presentation.alert.secondaryButton,
+                   let behavior = presentation.alert.secondaryButtonBehavior {
+                    switch behavior {
+                    case .custom:
+                        ButtonView(config: btn,
+                                   intent: OpenAlarmAppIntent(alarmID: state.alarmID.uuidString),
+                                   tint: openTint)
+                    case .countdown:
+                        ButtonView(config: btn,
+                                   intent: RepeatIntent(alarmID: state.alarmID.uuidString),
+                                   tint: repeatTint)
+                    @unknown default:
+                        EmptyView()
+                    }
                 }
             default:
                 EmptyView()

--- a/example/lib/presentation/widgets/alarm_controls.dart
+++ b/example/lib/presentation/widgets/alarm_controls.dart
@@ -102,6 +102,72 @@ class AlarmControls extends StatelessWidget {
             ),
             const SizedBox(height: 20),
             ElevatedButton(
+              onPressed: state.authStatus == 'Granted'
+                  ? () async {
+                      final plugin = FlutterAlarmkit();
+                      final id = await plugin.scheduleOneShotAlarm(
+                        timestamp: DateTime.now()
+                            .add(const Duration(seconds: 5))
+                            .millisecondsSinceEpoch
+                            .toDouble(),
+                        label: 'Open-App Alarm',
+                        tintColor: '#5856D6',
+                        uiConfig: const AlarmUIConfig(
+                          openAppButton: AlarmButtonConfig(
+                            text: 'Open',
+                            icon: 'arrow.up.forward.app',
+                            tintColor: '#5856D6',
+                          ),
+                        ),
+                      );
+                      debugPrint('Open-app alarm ID: $id');
+                    }
+                  : null,
+              child: const Text('Open-App Alarm (5s)'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: state.authStatus == 'Granted'
+                  ? () async {
+                      final fireAt =
+                          DateTime.now().add(const Duration(minutes: 1));
+                      await FlutterAlarmkit().scheduleRecurrentAlarm(
+                        weekdays: Weekday.everyday,
+                        hour: fireAt.hour,
+                        minute: fireAt.minute,
+                        label: 'Daily Alarm',
+                        tintColor: '#34C759',
+                      );
+                    }
+                  : null,
+              child: const Text('Daily Alarm (~1 min, repeats)'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: state.authStatus == 'Granted'
+                  ? () async {
+                      final fireAt =
+                          DateTime.now().add(const Duration(minutes: 1));
+                      await FlutterAlarmkit().scheduleRecurrentAlarm(
+                        weekdays: const {},
+                        hour: fireAt.hour,
+                        minute: fireAt.minute,
+                        label: 'Once Alarm',
+                        tintColor: '#FF9500',
+                      );
+                    }
+                  : null,
+              child: const Text('Once at Time (~1 min)'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () async {
+                await FlutterAlarmkit().cancelAll();
+              },
+              child: const Text('Cancel All'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
               onPressed: state.lastAlarmId != null
                   ? () {
                       context.read<AlarmBloc>().add(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   flutter_bloc:
     dependency: "direct main"
     description:

--- a/ios/WidgetTemplates/AlarmkitWidgetLiveActivity.swift
+++ b/ios/WidgetTemplates/AlarmkitWidgetLiveActivity.swift
@@ -200,6 +200,11 @@ struct AlarmControls: View {
         return .blue
     }
 
+    private var openTint: Color {
+        if let hex = tints["openTint"], let c = colorFromHex(hex) { return c }
+        return .blue
+    }
+
     var body: some View {
         HStack(spacing: 6) {
             switch state.mode {
@@ -216,12 +221,23 @@ struct AlarmControls: View {
                                tint: resumeTint)
                 }
             case .alert:
-                // Countdown alarms expose a secondary "repeat" button in the
-                // alert state; restart the countdown when it's tapped.
-                if let btn = presentation.alert.secondaryButton {
-                    ButtonView(config: btn,
-                               intent: RepeatIntent(alarmID: state.alarmID.uuidString),
-                               tint: repeatTint)
+                // The alert's secondary button is either a countdown "repeat"
+                // (countdown alarms) or a custom "open app" action (one-shot /
+                // recurrent alarms) — pick the intent by its declared behavior.
+                if let btn = presentation.alert.secondaryButton,
+                   let behavior = presentation.alert.secondaryButtonBehavior {
+                    switch behavior {
+                    case .custom:
+                        ButtonView(config: btn,
+                                   intent: OpenAlarmAppIntent(alarmID: state.alarmID.uuidString),
+                                   tint: openTint)
+                    case .countdown:
+                        ButtonView(config: btn,
+                                   intent: RepeatIntent(alarmID: state.alarmID.uuidString),
+                                   tint: repeatTint)
+                    @unknown default:
+                        EmptyView()
+                    }
                 }
             default:
                 EmptyView()

--- a/ios/flutter_alarmkit/Sources/flutter_alarmkit/AppIntents.swift
+++ b/ios/flutter_alarmkit/Sources/flutter_alarmkit/AppIntents.swift
@@ -110,7 +110,7 @@ struct OpenAlarmAppIntent: LiveActivityIntent {
     }
     
     static var title: LocalizedStringResource = "Open App"
-    static var description = IntentDescription("Opens the Sample app")
+    static var description = IntentDescription("Opens the app")
     static var openAppWhenRun = true
     
     @Parameter(title: "alarmID")

--- a/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
+++ b/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
@@ -121,6 +121,9 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     case "cancelAlarm":
       Task { await self.cancelAlarm(call: call, result: result) }
 
+    case "cancelAll":
+      Task { await self.cancelAll(result: result) }
+
     case "countdownAlarm":
       Task { await self.countdownAlarm(call: call, result: result) }
 
@@ -203,6 +206,9 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
   private static let defaultRepeatButton = ButtonConfig(
     text: "Repeat", textColor: .white, systemImageName: "repeat.circle", tintColor: .blue
   )
+  private static let defaultOpenButton = ButtonConfig(
+    text: "Open", textColor: .white, systemImageName: "arrow.up.forward.app", tintColor: .blue
+  )
 
   private func parseButtonConfig(
     from dict: [String: Any]?,
@@ -226,7 +232,7 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     return ButtonConfig(text: text, textColor: textColor, systemImageName: icon, tintColor: tintColor)
   }
 
-  private func storeButtonTints(alarmId: String, stop: ButtonConfig, pause: ButtonConfig? = nil, resume: ButtonConfig? = nil, repeatButton: ButtonConfig? = nil) {
+  private func storeButtonTints(alarmId: String, stop: ButtonConfig, pause: ButtonConfig? = nil, resume: ButtonConfig? = nil, repeatButton: ButtonConfig? = nil, openApp: ButtonConfig? = nil) {
     guard let defaults = UserDefaults(suiteName: AlarmkitPluginImpl.appGroupId) else {
       NSLog("⚠️ Could not access App Group UserDefaults (\(AlarmkitPluginImpl.appGroupId)). Button tint colors will use defaults.")
       return
@@ -242,6 +248,9 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     }
     if let repeatButton = repeatButton {
       tints["repeatTint"] = repeatButton.tintHexString
+    }
+    if let openApp = openApp {
+      tints["openTint"] = openApp.tintHexString
     }
     defaults.set(tints, forKey: "alarm_tints_\(alarmId)")
   }
@@ -306,7 +315,9 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     case .authorized:
       result(3)
     @unknown default:
-      result(0)
+      // Distinct sentinel so Dart maps this to AlarmAuthorizationState.unknown
+      // rather than collapsing into notDetermined (0).
+      result(-1)
     }
   }
 
@@ -508,13 +519,30 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
       from: uiConfigDict?["stopButton"] as? [String: Any],
       defaults: AlarmkitPluginImpl.defaultStopButton
     )
-
-    let alertContent = AlarmPresentation.Alert(
-      title: LocalizedStringResource(stringLiteral: label),
-      stopButton: stopConfig.toAlarmButton()
-    )
+    // Optional secondary "Open" button: opens the app and stops the alarm.
+    let openConfig: ButtonConfig? = (uiConfigDict?["openAppButton"] as? [String: Any]).map {
+      parseButtonConfig(from: $0, defaults: AlarmkitPluginImpl.defaultOpenButton)
+    }
 
     let tintColor = parseTintColor(from: args)
+
+    // Generate the id up front so it can back the secondary "Open" intent.
+    let id = UUID()
+
+    let alertContent: AlarmPresentation.Alert
+    if let openConfig = openConfig {
+      alertContent = AlarmPresentation.Alert(
+        title: LocalizedStringResource(stringLiteral: label),
+        stopButton: stopConfig.toAlarmButton(),
+        secondaryButton: openConfig.toAlarmButton(),
+        secondaryButtonBehavior: .custom
+      )
+    } else {
+      alertContent = AlarmPresentation.Alert(
+        title: LocalizedStringResource(stringLiteral: label),
+        stopButton: stopConfig.toAlarmButton()
+      )
+    }
 
     let presentation = AlarmPresentation(alert: alertContent)
 
@@ -524,23 +552,36 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     )
 
     let soundPath = parseSoundPath(from: args)
-    let alarmConfiguration = AlarmManager.AlarmConfiguration<NeverMetadata>(
+    let alarmConfiguration: AlarmManager.AlarmConfiguration<NeverMetadata>
+    if openConfig != nil {
+      // A `.custom` secondary button needs a secondaryIntent so the
+      // system-presented alert knows what to run (the widget's Button(intent:)
+      // only drives the Live Activity).
+      alarmConfiguration = .alarm(
         schedule: .fixed(date),
         attributes: attributes,
-        sound: resolveSoundAsset(soundPath),
-    )
+        stopIntent: nil,
+        secondaryIntent: OpenAlarmAppIntent(alarmID: id.uuidString),
+        sound: resolveSoundAsset(soundPath)
+      )
+    } else {
+      alarmConfiguration = AlarmManager.AlarmConfiguration<NeverMetadata>(
+        schedule: .fixed(date),
+        attributes: attributes,
+        sound: resolveSoundAsset(soundPath)
+      )
+    }
 
     // Persist presentation metadata BEFORE scheduling so the alarm-updates
     // stream's initial `add` event already carries the label/tint, and roll it
     // back if scheduling fails.
-    let id = UUID()
     storeAlarmMeta(
       alarmId: id.uuidString,
       label: label,
       tintColorHex: hexString(from: tintColor),
       createdAt: Date().timeIntervalSince1970
     )
-    storeButtonTints(alarmId: id.uuidString, stop: stopConfig)
+    storeButtonTints(alarmId: id.uuidString, stop: stopConfig, openApp: openConfig)
 
     do {
       let alarm = try await manager.schedule(
@@ -721,10 +762,10 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
       ))
       return
     }
-    guard mask != 0 else {
+    guard mask & ~0x7F == 0 else {
       result(FlutterError(
         code: "BAD_ARGS",
-        message: "Invalid weekdayMask: expected at least one selected weekday.",
+        message: "Invalid weekdayMask: expected weekday bits only (0...0x7F).",
         details: nil
       ))
       return
@@ -749,9 +790,11 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     // 3. Decode bitmask into weekdays
     let weekdays = decodeWeekdays(from: mask)
 
-    // 4. Build the weekly schedule
+    // 4. Build the relative schedule. An empty mask means "fire once" (.never);
+    //    otherwise repeat weekly on the selected weekdays.
     let time = Alarm.Schedule.Relative.Time(hour: hour, minute: minute)
-    let recurrence = Alarm.Schedule.Relative.Recurrence.weekly(weekdays)
+    let recurrence: Alarm.Schedule.Relative.Recurrence =
+      weekdays.isEmpty ? .never : .weekly(weekdays)
     let schedule = Alarm.Schedule.Relative(time: time, repeats: recurrence)
 
     // 5. Build presentation UI
@@ -762,13 +805,29 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
       from: uiConfigDict?["stopButton"] as? [String: Any],
       defaults: AlarmkitPluginImpl.defaultStopButton
     )
+    // Optional secondary "Open" button: opens the app and stops the alarm.
+    let openConfig: ButtonConfig? = (uiConfigDict?["openAppButton"] as? [String: Any]).map {
+      parseButtonConfig(from: $0, defaults: AlarmkitPluginImpl.defaultOpenButton)
+    }
 
-    let presentation = AlarmPresentation(
-      alert: AlarmPresentation.Alert(
+    // Generate the id up front so it can back the secondary "Open" intent.
+    let id = UUID()
+
+    let alertContent: AlarmPresentation.Alert
+    if let openConfig = openConfig {
+      alertContent = AlarmPresentation.Alert(
+        title: LocalizedStringResource(stringLiteral: label),
+        stopButton: stopConfig.toAlarmButton(),
+        secondaryButton: openConfig.toAlarmButton(),
+        secondaryButtonBehavior: .custom
+      )
+    } else {
+      alertContent = AlarmPresentation.Alert(
         title: LocalizedStringResource(stringLiteral: label),
         stopButton: stopConfig.toAlarmButton()
       )
-    )
+    }
+    let presentation = AlarmPresentation(alert: alertContent)
     let tintColor = parseTintColor(from: args)
     let attributes = AlarmAttributes<NeverMetadata>(
       presentation: presentation,
@@ -777,21 +836,31 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
 
     // 6. Configure and schedule
     let soundPath = parseSoundPath(from: args)
-    let config = AlarmManager
-      .AlarmConfiguration<NeverMetadata>(
+    let config: AlarmManager.AlarmConfiguration<NeverMetadata>
+    if openConfig != nil {
+      // `.custom` secondary needs a secondaryIntent for the system alert.
+      config = .alarm(
         schedule: .relative(schedule),
         attributes: attributes,
-        sound: resolveSoundAsset(soundPath),
+        stopIntent: nil,
+        secondaryIntent: OpenAlarmAppIntent(alarmID: id.uuidString),
+        sound: resolveSoundAsset(soundPath)
       )
+    } else {
+      config = AlarmManager.AlarmConfiguration<NeverMetadata>(
+        schedule: .relative(schedule),
+        attributes: attributes,
+        sound: resolveSoundAsset(soundPath)
+      )
+    }
 
-    let id = UUID()
     storeAlarmMeta(
       alarmId: id.uuidString,
       label: label,
       tintColorHex: hexString(from: tintColor),
       createdAt: Date().timeIntervalSince1970
     )
-    storeButtonTints(alarmId: id.uuidString, stop: stopConfig)
+    storeButtonTints(alarmId: id.uuidString, stop: stopConfig, openApp: openConfig)
 
     do {
       let alarm = try await manager.schedule(
@@ -878,6 +947,43 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
         code: "CANCEL_ERROR",
         message: "Failed to cancel alarm \(parsed.alarmId): \(error.localizedDescription)",
         details: nil
+      ))
+    }
+  }
+
+  private func cancelAll(result: @escaping FlutterResult) async {
+    let manager = AlarmManager.shared
+
+    let alarms: [Alarm]
+    do {
+      alarms = try manager.alarms
+    } catch {
+      result(FlutterError(
+        code: "CANCEL_ALL_ERROR",
+        message: "Failed to fetch alarms: \(error.localizedDescription)",
+        details: nil
+      ))
+      return
+    }
+
+    // Attempt every alarm independently so one failure doesn't block the rest.
+    var failedIds: [String] = []
+    for alarm in alarms {
+      do {
+        try manager.cancel(id: alarm.id)
+        removeAlarmPersistence(alarm.id.uuidString)
+      } catch {
+        failedIds.append(alarm.id.uuidString)
+      }
+    }
+
+    if failedIds.isEmpty {
+      result(nil)
+    } else {
+      result(FlutterError(
+        code: "CANCEL_ALL_ERROR",
+        message: "Failed to cancel \(failedIds.count) of \(alarms.count) alarm(s).",
+        details: failedIds
       ))
     }
   }

--- a/lib/flutter_alarmkit.dart
+++ b/lib/flutter_alarmkit.dart
@@ -3,6 +3,7 @@ import 'package:flutter_alarmkit/flutter_alarmkit_method_channel.dart';
 
 import 'package:flutter_alarmkit/flutter_alarmkit_platform_interface.dart';
 import 'package:flutter_alarmkit/src/alarm.dart';
+import 'package:flutter_alarmkit/src/alarm_authorization_state.dart';
 import 'package:flutter_alarmkit/src/alarm_ui_config.dart';
 import 'package:flutter_alarmkit/src/alarm_update_event.dart';
 import 'package:flutter_alarmkit/src/weekday.dart' show Weekday;
@@ -16,6 +17,7 @@ export 'src/alarm.dart'
         FixedAlarmSchedule,
         RelativeAlarmSchedule,
         UnknownAlarmSchedule;
+export 'src/alarm_authorization_state.dart' show AlarmAuthorizationState;
 export 'src/alarm_button_config.dart' show AlarmButtonConfig;
 export 'src/alarm_ui_config.dart' show AlarmUIConfig;
 export 'src/alarm_update_event.dart' show AlarmUpdateEvent, AlarmUpdateKind;
@@ -52,16 +54,13 @@ class FlutterAlarmkit {
 
   /// Gets the current authorization state of AlarmKit.
   ///
-  /// Returns a [Future<int>] that completes with the raw value of the
-  /// authorization state:
-  /// - 0: notDetermined
-  /// - 1: restricted
-  /// - 2: denied
-  /// - 3: authorized
+  /// Returns a [Future] that completes with the [AlarmAuthorizationState]:
+  /// [AlarmAuthorizationState.notDetermined], [AlarmAuthorizationState.denied],
+  /// [AlarmAuthorizationState.authorized], or [AlarmAuthorizationState.unknown].
   ///
   /// Throws a [PlatformException] if the platform version is not supported
   /// (iOS < 26.0)
-  Future<int> getAuthorizationState() {
+  Future<AlarmAuthorizationState> getAuthorizationState() {
     return FlutterAlarmkitPlatform.instance.getAuthorizationState();
   }
 
@@ -192,10 +191,11 @@ class FlutterAlarmkit {
     );
   }
 
-  /// Schedules a recurrent alarm for the specified weekdays and time.
+  /// Schedules a relative alarm for the given time, repeating on [weekdays].
   ///
-  /// [weekdays] is a set of weekdays when the alarm should trigger;
-  /// it must contain at least one weekday.
+  /// [weekdays] is the set of weekdays the alarm repeats on. Pass
+  /// [Weekday.everyday] (all seven) for a daily alarm, or an **empty set** to
+  /// fire once at the next occurrence of [hour]:[minute] without repeating.
   /// [hour] is the hour of the day (0-23)
   /// [minute] is the minute of the hour (0-59)
   /// [label] is an optional string that will be displayed as the alarm title.
@@ -238,13 +238,6 @@ class FlutterAlarmkit {
     String? soundPath,
     AlarmUIConfig? uiConfig,
   }) {
-    if (weekdays.isEmpty) {
-      throw ArgumentError.value(
-        weekdays,
-        'weekdays',
-        'A recurrent alarm requires at least one weekday.',
-      );
-    }
     return FlutterAlarmkitPlatform.instance.scheduleRecurrentAlarm(
       weekdayMask: Weekday.toBitmask(weekdays),
       hour: hour,
@@ -278,6 +271,20 @@ class FlutterAlarmkit {
   /// system rejected the request).
   Future<bool> cancelAlarm({required String alarmId}) {
     return FlutterAlarmkitPlatform.instance.cancelAlarm(alarmId: alarmId);
+  }
+
+  /// Cancels every alarm currently known to the system.
+  ///
+  /// Operates on the snapshot of alarms the system reports at call time. Each
+  /// alarm is attempted independently, so one failure does not prevent the
+  /// others from being cancelled.
+  ///
+  /// Throws a [PlatformException] with code `CANCEL_ALL_ERROR` if any
+  /// individual cancellation fails; its `details` is the list of alarm IDs
+  /// that could not be cancelled. Also throws if the platform version is not
+  /// supported (iOS < 26.0).
+  Future<void> cancelAll() {
+    return FlutterAlarmkitPlatform.instance.cancelAll();
   }
 
   /// Pauses the alarm with the specified ID if it's in the countdown state.

--- a/lib/flutter_alarmkit_method_channel.dart
+++ b/lib/flutter_alarmkit_method_channel.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import 'package:flutter_alarmkit/flutter_alarmkit_platform_interface.dart';
 import 'package:flutter_alarmkit/src/alarm.dart';
+import 'package:flutter_alarmkit/src/alarm_authorization_state.dart';
 import 'package:flutter_alarmkit/src/alarm_update_event.dart';
 
 /// An implementation of [FlutterAlarmkitPlatform] that uses method channels.
@@ -45,11 +46,12 @@ class MethodChannelFlutterAlarmkit extends FlutterAlarmkitPlatform {
   }
 
   @override
-  Future<int> getAuthorizationState() async {
+  Future<AlarmAuthorizationState> getAuthorizationState() async {
     try {
-      final state =
-          await methodChannel.invokeMethod<int>('getAuthorizationState') ?? 0;
-      return state;
+      final state = await methodChannel.invokeMethod<int>(
+        'getAuthorizationState',
+      );
+      return AlarmAuthorizationState.fromRaw(state);
     } on PlatformException catch (e) {
       _rethrowMapped(e);
     }
@@ -248,6 +250,15 @@ class MethodChannelFlutterAlarmkit extends FlutterAlarmkitPlatform {
         '[FlutterAlarmkit] Failed to cancel alarm $alarmId: [${e.code}] ${e.message}',
       );
       return false;
+    }
+  }
+
+  @override
+  Future<void> cancelAll() async {
+    try {
+      await methodChannel.invokeMethod<void>('cancelAll');
+    } on PlatformException catch (e) {
+      _rethrowMapped(e);
     }
   }
 

--- a/lib/flutter_alarmkit_platform_interface.dart
+++ b/lib/flutter_alarmkit_platform_interface.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter_alarmkit/flutter_alarmkit_method_channel.dart';
 import 'package:flutter_alarmkit/src/alarm.dart';
+import 'package:flutter_alarmkit/src/alarm_authorization_state.dart';
 import 'package:flutter_alarmkit/src/alarm_update_event.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -37,7 +38,7 @@ abstract class FlutterAlarmkitPlatform extends PlatformInterface {
     );
   }
 
-  Future<int> getAuthorizationState() {
+  Future<AlarmAuthorizationState> getAuthorizationState() {
     throw UnimplementedError(
       'getAuthorizationState() has not been implemented.',
     );
@@ -94,6 +95,10 @@ abstract class FlutterAlarmkitPlatform extends PlatformInterface {
 
   Future<bool> cancelAlarm({required String alarmId}) {
     throw UnimplementedError('cancelAlarm() has not been implemented.');
+  }
+
+  Future<void> cancelAll() {
+    throw UnimplementedError('cancelAll() has not been implemented.');
   }
 
   Future<bool> stopAlarm({required String alarmId}) {

--- a/lib/src/alarm_authorization_state.dart
+++ b/lib/src/alarm_authorization_state.dart
@@ -1,0 +1,35 @@
+/// The app's authorization to schedule alarms, mirroring AlarmKit's
+/// `AlarmManager.AuthorizationState`.
+enum AlarmAuthorizationState {
+  /// The user has not yet been asked for permission.
+  notDetermined,
+
+  /// Permission has been denied (or not granted).
+  denied,
+
+  /// The app is allowed to schedule alarms.
+  authorized,
+
+  /// The state could not be mapped — e.g. a future AlarmKit state this
+  /// version of the plugin does not yet know about.
+  unknown;
+
+  /// Maps the raw integer from the platform channel to an
+  /// [AlarmAuthorizationState].
+  ///
+  /// `0` → [notDetermined], `2` → [denied], `3` → [authorized]. `null`, the
+  /// `-1` sentinel, and any unrecognized value map to [unknown], keeping the
+  /// API forward-compatible with future iOS releases.
+  static AlarmAuthorizationState fromRaw(int? raw) {
+    switch (raw) {
+      case 0:
+        return AlarmAuthorizationState.notDetermined;
+      case 2:
+        return AlarmAuthorizationState.denied;
+      case 3:
+        return AlarmAuthorizationState.authorized;
+      default:
+        return AlarmAuthorizationState.unknown;
+    }
+  }
+}

--- a/lib/src/alarm_ui_config.dart
+++ b/lib/src/alarm_ui_config.dart
@@ -56,6 +56,17 @@ class AlarmUIConfig {
   /// tintColor=system blue.
   final AlarmButtonConfig? repeatButton;
 
+  /// Secondary "Open" button shown in the alert state for one-shot and
+  /// recurrent (relative) alarms. Tapping it opens the app and stops the alarm.
+  ///
+  /// Ignored for countdown alarms, which use [repeatButton] as their alert
+  /// secondary button. When null, no secondary button is shown for one-shot /
+  /// recurrent alarms (just Stop).
+  ///
+  /// Defaults (when provided without overrides): text="Open",
+  /// icon="arrow.up.forward.app", textColor=white, tintColor=system blue.
+  final AlarmButtonConfig? openAppButton;
+
   /// Title shown during the countdown state.
   /// If null, uses the alarm's main label.
   final String? countdownTitle;
@@ -70,6 +81,7 @@ class AlarmUIConfig {
     this.pauseButton,
     this.resumeButton,
     this.repeatButton,
+    this.openAppButton,
     this.countdownTitle,
     this.pausedTitle,
   });
@@ -81,6 +93,7 @@ class AlarmUIConfig {
       if (pauseButton != null) 'pauseButton': pauseButton!.toMap(),
       if (resumeButton != null) 'resumeButton': resumeButton!.toMap(),
       if (repeatButton != null) 'repeatButton': repeatButton!.toMap(),
+      if (openAppButton != null) 'openAppButton': openAppButton!.toMap(),
       if (countdownTitle != null) 'countdownTitle': countdownTitle,
       if (pausedTitle != null) 'pausedTitle': pausedTitle,
     };
@@ -94,16 +107,17 @@ class AlarmUIConfig {
           other.pauseButton == pauseButton &&
           other.resumeButton == resumeButton &&
           other.repeatButton == repeatButton &&
+          other.openAppButton == openAppButton &&
           other.countdownTitle == countdownTitle &&
           other.pausedTitle == pausedTitle;
 
   @override
   int get hashCode => Object.hash(stopButton, pauseButton, resumeButton,
-      repeatButton, countdownTitle, pausedTitle);
+      repeatButton, openAppButton, countdownTitle, pausedTitle);
 
   @override
   String toString() => 'AlarmUIConfig(stopButton: $stopButton, '
       'pauseButton: $pauseButton, resumeButton: $resumeButton, '
-      'repeatButton: $repeatButton, countdownTitle: $countdownTitle, '
-      'pausedTitle: $pausedTitle)';
+      'repeatButton: $repeatButton, openAppButton: $openAppButton, '
+      'countdownTitle: $countdownTitle, pausedTitle: $pausedTitle)';
 }

--- a/lib/src/weekday.dart
+++ b/lib/src/weekday.dart
@@ -26,6 +26,17 @@ enum Weekday {
   /// Sunday (enum position 6).
   sunday;
 
+  /// All seven weekdays. Pass to `scheduleRecurrentAlarm` for a daily alarm.
+  static const Set<Weekday> everyday = {
+    monday,
+    tuesday,
+    wednesday,
+    thursday,
+    friday,
+    saturday,
+    sunday,
+  };
+
   /// Converts a set of weekdays to a bitmask.
   ///
   /// Each weekday occupies the bit at its enum position:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_alarmkit
 description: "Flutter plugin for Apple AlarmKit (iOS 26+). Schedule one-shot, countdown, and recurring alarms as Lock Screen and Dynamic Island Live Activities."
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/gdelataillade/flutter_alarmkit
 
 environment:

--- a/test/alarm_authorization_state_test.dart
+++ b/test/alarm_authorization_state_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_alarmkit/flutter_alarmkit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AlarmAuthorizationState.fromRaw', () {
+    test('maps the known raw values', () {
+      expect(
+        AlarmAuthorizationState.fromRaw(0),
+        AlarmAuthorizationState.notDetermined,
+      );
+      expect(
+        AlarmAuthorizationState.fromRaw(2),
+        AlarmAuthorizationState.denied,
+      );
+      expect(
+        AlarmAuthorizationState.fromRaw(3),
+        AlarmAuthorizationState.authorized,
+      );
+    });
+
+    test('maps the -1 sentinel, null, and unrecognized values to unknown', () {
+      expect(
+        AlarmAuthorizationState.fromRaw(-1),
+        AlarmAuthorizationState.unknown,
+      );
+      expect(
+        AlarmAuthorizationState.fromRaw(null),
+        AlarmAuthorizationState.unknown,
+      );
+      // 1 was the old bogus "restricted" value — it must not map to anything.
+      expect(
+        AlarmAuthorizationState.fromRaw(1),
+        AlarmAuthorizationState.unknown,
+      );
+      expect(
+        AlarmAuthorizationState.fromRaw(99),
+        AlarmAuthorizationState.unknown,
+      );
+    });
+  });
+}

--- a/test/alarm_ui_config_test.dart
+++ b/test/alarm_ui_config_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_alarmkit/flutter_alarmkit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AlarmUIConfig.toMap', () {
+    test('includes openAppButton when set', () {
+      const config = AlarmUIConfig(
+        openAppButton: AlarmButtonConfig(
+          text: 'Open',
+          icon: 'arrow.up.forward.app',
+        ),
+      );
+
+      final map = config.toMap();
+      expect(map.containsKey('openAppButton'), isTrue);
+      expect((map['openAppButton']! as Map)['text'], 'Open');
+    });
+
+    test('omits openAppButton when null', () {
+      const config = AlarmUIConfig(
+        stopButton: AlarmButtonConfig(text: 'Stop', icon: 'stop.circle'),
+      );
+
+      expect(config.toMap().containsKey('openAppButton'), isFalse);
+    });
+  });
+
+  group('AlarmUIConfig equality', () {
+    test('covers the openAppButton field', () {
+      const a = AlarmUIConfig(
+        openAppButton: AlarmButtonConfig(text: 'Open', icon: 'a'),
+      );
+      const same = AlarmUIConfig(
+        openAppButton: AlarmButtonConfig(text: 'Open', icon: 'a'),
+      );
+      const different = AlarmUIConfig(
+        openAppButton: AlarmButtonConfig(text: 'Launch', icon: 'a'),
+      );
+
+      expect(a, same);
+      expect(a.hashCode, same.hashCode);
+      expect(a, isNot(different));
+    });
+  });
+}

--- a/test/flutter_alarmkit_method_channel_test.dart
+++ b/test/flutter_alarmkit_method_channel_test.dart
@@ -65,4 +65,65 @@ void main() {
 
     expect(await platform.getAlarms(), isEmpty);
   });
+
+  test('getAuthorizationState maps known and sentinel raw ints', () async {
+    int? reply;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      return call.method == 'getAuthorizationState' ? reply : null;
+    });
+
+    reply = 0;
+    expect(
+      await platform.getAuthorizationState(),
+      AlarmAuthorizationState.notDetermined,
+    );
+    reply = 2;
+    expect(
+      await platform.getAuthorizationState(),
+      AlarmAuthorizationState.denied,
+    );
+    reply = 3;
+    expect(
+      await platform.getAuthorizationState(),
+      AlarmAuthorizationState.authorized,
+    );
+    reply = -1;
+    expect(
+      await platform.getAuthorizationState(),
+      AlarmAuthorizationState.unknown,
+    );
+    reply = null;
+    expect(
+      await platform.getAuthorizationState(),
+      AlarmAuthorizationState.unknown,
+    );
+  });
+
+  test('cancelAll invokes the cancelAll method', () async {
+    var called = false;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'cancelAll') called = true;
+      return null;
+    });
+
+    await platform.cancelAll();
+    expect(called, isTrue);
+  });
+
+  test('cancelAll rethrows a CANCEL_ALL_ERROR PlatformException', () async {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      throw PlatformException(
+        code: 'CANCEL_ALL_ERROR',
+        message: 'fail',
+        details: ['id-1'],
+      );
+    });
+
+    await expectLater(
+      platform.cancelAll(),
+      throwsA(
+        isA<PlatformException>().having((e) => e.code, 'code', 'CANCEL_ALL_ERROR'),
+      ),
+    );
+  });
 }

--- a/test/flutter_alarmkit_test.dart
+++ b/test/flutter_alarmkit_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_alarmkit/flutter_alarmkit.dart';
+import 'package:flutter_alarmkit/flutter_alarmkit_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// Records the arguments the public API forwards to the platform layer.
+class _RecordingPlatform extends FlutterAlarmkitPlatform
+    with MockPlatformInterfaceMixin {
+  int? lastWeekdayMask;
+
+  @override
+  Future<String> scheduleRecurrentAlarm({
+    required int weekdayMask,
+    required int hour,
+    required int minute,
+    String? label,
+    String? tintColor,
+    String? soundPath,
+    Map<String, dynamic>? uiConfig,
+  }) async {
+    lastWeekdayMask = weekdayMask;
+    return 'mock-id';
+  }
+}
+
+void main() {
+  late _RecordingPlatform platform;
+  late FlutterAlarmkit plugin;
+
+  setUp(() {
+    platform = _RecordingPlatform();
+    FlutterAlarmkitPlatform.instance = platform;
+    plugin = FlutterAlarmkit();
+  });
+
+  group('scheduleRecurrentAlarm weekday handling', () {
+    test('empty weekdays no longer throws and forwards mask 0 (fires once)',
+        () async {
+      final id = await plugin.scheduleRecurrentAlarm(
+        weekdays: {},
+        hour: 7,
+        minute: 0,
+      );
+
+      expect(id, 'mock-id');
+      expect(platform.lastWeekdayMask, 0);
+    });
+
+    test('Weekday.everyday forwards mask 127 (daily)', () async {
+      await plugin.scheduleRecurrentAlarm(
+        weekdays: Weekday.everyday,
+        hour: 7,
+        minute: 0,
+      );
+
+      expect(platform.lastWeekdayMask, 127);
+    });
+
+    test('a specific weekday set forwards the matching bitmask', () async {
+      await plugin.scheduleRecurrentAlarm(
+        weekdays: {Weekday.monday, Weekday.sunday},
+        hour: 7,
+        minute: 0,
+      );
+
+      expect(platform.lastWeekdayMask, 1 | 64);
+    });
+  });
+}

--- a/test/weekday_test.dart
+++ b/test/weekday_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_alarmkit/flutter_alarmkit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Weekday.everyday', () {
+    test('contains all seven weekdays', () {
+      expect(Weekday.everyday, Weekday.values.toSet());
+      expect(Weekday.everyday.length, 7);
+    });
+
+    test('encodes to 127 (all seven low bits set)', () {
+      expect(Weekday.toBitmask(Weekday.everyday), 127);
+    });
+  });
+
+  group('Weekday.toBitmask', () {
+    test('empty set encodes to 0', () {
+      expect(Weekday.toBitmask({}), 0);
+    });
+
+    test('monday is bit 0 and sunday is bit 6', () {
+      expect(Weekday.toBitmask({Weekday.monday}), 1);
+      expect(Weekday.toBitmask({Weekday.sunday}), 64);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Four independent roadmap items that round out the API (bumps to **0.4.0**). Follows [#10](https://github.com/gdelataillade/flutter_alarmkit/pull/10).

### #3 — "Open app" secondary button
`AlarmUIConfig.openAppButton` gives one-shot and recurrent alarms an **Open + Stop** alert (the canonical alarm-clock flow). This wires up the previously-dead `OpenAlarmAppIntent`:
- The plugin generates the alarm UUID first, then pairs `secondaryButtonBehavior: .custom` with `secondaryIntent: OpenAlarmAppIntent(...)` in the `AlarmConfiguration` — so the **system-presented alert** invokes it, not just the Live Activity.
- The widget routes the alert secondary by behavior: `.custom` → Open, `.countdown` → Repeat (existing), `@unknown` → none. Widget edits are mirrored **byte-identically** to the example copy (verified; `setup --doctor` passes).
- Countdown alarms are unchanged (they keep their Repeat secondary).

### #5 — One-time & daily relative alarms
`scheduleRecurrentAlarm` now accepts an **empty `weekdays` set** → fires once at the next occurrence of the time (`Recurrence.never`); new **`Weekday.everyday`** helper → daily. Native range-checks the mask (`mask & ~0x7F == 0`) so an invalid mask errors instead of silently degrading to `.never`.

### #6 — `cancelAll()`
Cancels every alarm in the system snapshot, attempting each independently (one failure doesn't block the rest), cleaning persisted metadata per success, and throwing a single `CANCEL_ALL_ERROR` (failed IDs in `details`) if any fail.

### #7 — Typed `AlarmAuthorizationState`  (BREAKING)
`getAuthorizationState()` returns `AlarmAuthorizationState { notDetermined, denied, authorized, unknown }` instead of a raw `int`. Swift's `@unknown default` now returns a `-1` sentinel so `unknown` is actually reachable (previously collapsed into `notDetermined`); the bogus "1: restricted" doc value is gone.

> Item #4 (custom `AlarmMetadata`) is intentionally deferred — larger and touches the byte-identical widget templates.

## Test plan
- `flutter analyze` clean (root + example); **36 tests pass** — added `weekday`, `alarm_authorization_state`, `alarm_ui_config`, a mock-platform test for the recurrence relaxation, and method-channel coverage for the auth mapping + `cancelAll`.
- Widget template copies byte-identical; `dart run flutter_alarmkit:setup --doctor` passes all 8 checks.
- Example app gains demo buttons (open-app one-shot, daily, once, cancel-all) calling `FlutterAlarmkit` directly; the live list still updates via the `alarmUpdates` stream.
- Manual on-device (iOS 26) pending: Open + Stop alert and tap-to-open; daily/once relative firing; `cancelAll` clearing the list.
- Build-time SDK confirmation (all confirmed in Apple docs): `SecondaryButtonBehavior.custom`, the `.alarm(...secondaryIntent:...)` factory, `Recurrence.never`, and `secondaryButtonBehavior` reading back in the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)