### PR TITLE
Fixed countdown no repeat trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.1
+* Fix `setCountdownAlarm` crashing (AlarmKit precondition trap) when `repeatDurationInSeconds` is `0` — a non-repeating countdown now schedules correctly and shows a stop-only alert. Thanks @bboybboy!
+
 ## 0.3.0
 * **Breaking:** `getAlarms()` → `Future<List<Alarm>>` and `alarmUpdates()` → `Stream<AlarmUpdateEvent>`, reporting full state (scheduled/countdown/paused/alerting).
 * Custom alarm metadata (`AlarmMetadata`: SF Symbol icon + subtitle) — rendered in the Live Activity and returned by `getAlarms()`.

--- a/example/lib/presentation/widgets/alarm_controls.dart
+++ b/example/lib/presentation/widgets/alarm_controls.dart
@@ -67,6 +67,21 @@ class _AlarmControlsState extends State<AlarmControls> {
             },
           ),
           _ExampleAction(
+            icon: CupertinoIcons.timer,
+            title: 'Simple timer',
+            subtitle: '15 sec countdown · no repeat',
+            color: CupertinoColors.systemTeal,
+            onPressed: () async {
+              final id = await plugin.setCountdownAlarm(
+                countdownDurationInSeconds: 15,
+                repeatDurationInSeconds: 0,
+                label: 'Simple Timer',
+                tintColor: '#30B0C7',
+              );
+              debugPrint('Simple timer alarm ID: $id');
+            },
+          ),
+          _ExampleAction(
             icon: CupertinoIcons.slider_horizontal_3,
             title: 'Custom alarm UI',
             subtitle: '15 sec countdown · custom buttons',

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.3.1"
   flutter_bloc:
     dependency: "direct main"
     description:

--- a/ios/flutter_alarmkit.podspec
+++ b/ios/flutter_alarmkit.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_alarmkit'
-  s.version          = '0.3.0'
+  s.version          = '0.3.1'
   s.summary          = 'Flutter plugin wrapping Apple AlarmKit (iOS 26+) with Live Activity alarms.'
   s.description      = <<-DESC
 Schedule one-shot, countdown, and recurrent AlarmKit alarms that present as Live

--- a/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
+++ b/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
@@ -630,9 +630,13 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     }
 
     let label = parseLabel(from: args)
+    // A zero repeat duration means a non-repeating countdown: AlarmKit traps if
+    // a `.countdown` secondary button is paired with a zero/absent postAlert,
+    // so both must be omitted together.
+    let repeats = postSec > 0
     let countdownDuration = Alarm.CountdownDuration(
       preAlert: TimeInterval(preSec),
-      postAlert: postSec > 0 ? TimeInterval(postSec) : nil)
+      postAlert: repeats ? TimeInterval(postSec) : nil)
     let uiConfigDict = args["uiConfig"] as? [String: Any]
 
     let stopConfig = parseButtonConfig(
@@ -655,19 +659,13 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     let countdownTitle = uiConfigDict?["countdownTitle"] as? String ?? label
     let pausedTitle = uiConfigDict?["pausedTitle"] as? String ?? label
 
-    let alert: AlarmPresentation.Alert = postSec > 0
-      ? AlarmPresentation.Alert(
-          title: LocalizedStringResource(stringLiteral: label),
-          stopButton: stopConfig.toAlarmButton(),
-          secondaryButton: repeatConfig.toAlarmButton(),
-          secondaryButtonBehavior: .countdown
-        )
-      : AlarmPresentation.Alert(
-          title: LocalizedStringResource(stringLiteral: label),
-          stopButton: stopConfig.toAlarmButton()
-        )
     let presentation = AlarmPresentation(
-      alert: alert,
+      alert: AlarmPresentation.Alert(
+        title: LocalizedStringResource(stringLiteral: label),
+        stopButton: stopConfig.toAlarmButton(),
+        secondaryButton: repeats ? repeatConfig.toAlarmButton() : nil,
+        secondaryButtonBehavior: repeats ? .countdown : nil
+      ),
       countdown: AlarmPresentation.Countdown(
         title: LocalizedStringResource(stringLiteral: countdownTitle),
         pauseButton: pauseConfig.toAlarmButton()

--- a/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
+++ b/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
@@ -630,7 +630,9 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     }
 
     let label = parseLabel(from: args)
-    let countdownDuration = Alarm.CountdownDuration(preAlert: TimeInterval(preSec), postAlert: TimeInterval(postSec))
+    let countdownDuration = Alarm.CountdownDuration(
+      preAlert: TimeInterval(preSec),
+      postAlert: postSec > 0 ? TimeInterval(postSec) : nil)
     let uiConfigDict = args["uiConfig"] as? [String: Any]
 
     let stopConfig = parseButtonConfig(
@@ -653,13 +655,19 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     let countdownTitle = uiConfigDict?["countdownTitle"] as? String ?? label
     let pausedTitle = uiConfigDict?["pausedTitle"] as? String ?? label
 
+    let alert: AlarmPresentation.Alert = postSec > 0
+      ? AlarmPresentation.Alert(
+          title: LocalizedStringResource(stringLiteral: label),
+          stopButton: stopConfig.toAlarmButton(),
+          secondaryButton: repeatConfig.toAlarmButton(),
+          secondaryButtonBehavior: .countdown
+        )
+      : AlarmPresentation.Alert(
+          title: LocalizedStringResource(stringLiteral: label),
+          stopButton: stopConfig.toAlarmButton()
+        )
     let presentation = AlarmPresentation(
-      alert: AlarmPresentation.Alert(
-        title: LocalizedStringResource(stringLiteral: label),
-        stopButton: stopConfig.toAlarmButton(),
-        secondaryButton: repeatConfig.toAlarmButton(),
-        secondaryButtonBehavior: .countdown
-      ),
+      alert: alert,
       countdown: AlarmPresentation.Countdown(
         title: LocalizedStringResource(stringLiteral: countdownTitle),
         pauseButton: pauseConfig.toAlarmButton()

--- a/lib/flutter_alarmkit.dart
+++ b/lib/flutter_alarmkit.dart
@@ -139,7 +139,10 @@ class FlutterAlarmkit {
   /// Schedules a countdown alarm for the specified duration.
   ///
   /// [countdownDurationInSeconds] is the duration of the countdown in seconds.
-  /// [repeatDurationInSeconds] is the duration of the repeat in seconds.
+  /// [repeatDurationInSeconds] is the duration of the repeat countdown in
+  /// seconds, started when the user taps the repeat button on the alert. Pass
+  /// `0` for a non-repeating countdown (a simple timer): the alert then shows
+  /// only the stop button, and any `repeatButton` in [uiConfig] is ignored.
   /// [label] is an optional string that will be displayed as the alarm title.
   /// [tintColor] is an optional string representing a color that helps users
   /// associate the alarm with your app. Must be in the form `#RRGGBB`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_alarmkit
 description: "Flutter plugin for Apple AlarmKit (iOS 26+). Schedule one-shot, countdown, and recurring alarms as Lock Screen and Dynamic Island Live Activities."
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/gdelataillade/flutter_alarmkit
 
 environment:


### PR DESCRIPTION
### Problem
`setCountdownAlarm` crashes with `EXC_BREAKPOINT` (AlarmKit `brk 1` precondition
trap) whenever `repeatDurationInSeconds` is `0` - i.e. a plain, non-repeating
countdown such as a simple timer. The alarm never schedules and the app dies.

### Cause
For a non-repeating countdown the code still:
- passed `postAlert: TimeInterval(0)` to `Alarm.CountdownDuration`, and
- always attached a `.countdown` repeat secondary button.

AlarmKit preconditions on a `.countdown` repeat behavior paired with a
zero/absent post-alert interval and traps.

### Fix
When there is no repeat interval (`repeatDurationInSeconds == 0`):
- pass `postAlert: nil` instead of `TimeInterval(0)`, and
- build a stop-only `AlarmPresentation.Alert`

Repeating countdowns (`> 0`) are unchanged.