### PR TITLE
Refresh stale custom-sound copies; key Library/Sounds copies by asset path (0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.3
+* Fix custom alarm sounds going stale: the copy in `Library/Sounds` is now refreshed automatically when the asset's content changes (previously the first copy played forever), and copies are keyed by the full asset path so same-named files in different asset folders no longer clobber each other.
+
 ## 0.3.1
 * Fix `setCountdownAlarm` crashing (AlarmKit precondition trap) when `repeatDurationInSeconds` is `0`.
 * Declare the shared `UserDefaults` (App Group) access in the privacy manifests (plugin + widget) for App Store Required Reason API compliance.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.1"
+    version: "0.3.3"
   flutter_bloc:
     dependency: "direct main"
     description:

--- a/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
+++ b/ios/flutter_alarmkit/Sources/flutter_alarmkit/FlutterAlarmkitPlugin.swift
@@ -1,5 +1,6 @@
 import Flutter
 import ActivityKit
+import CryptoKit
 import UIKit
 import AlarmKit
 import SwiftUI
@@ -439,9 +440,14 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
       return .default
     }
 
-    // 1. Get the filename from the asset path (e.g., "assets/marimba.caf" -> "marimba.caf")
-    let fileName = URL(fileURLWithPath: assetPath).lastPathComponent
-    
+    // 1. Derive the copy's name from the full asset path, not just the
+    // basename, so two assets with the same filename in different folders
+    // (e.g. "assets/soft/ring.caf" and "assets/loud/ring.caf") get distinct
+    // copies instead of silently clobbering each other. The name is internal —
+    // AlarmKit only uses it to locate the copy in Library/Sounds.
+    let baseName = URL(fileURLWithPath: assetPath).lastPathComponent
+    let fileName = "\(Self.stableDigest(of: assetPath))-\(baseName)"
+
     // 2. Define the target URL in Library/Sounds
     let fileManager = FileManager.default
     guard let libraryUrl = fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first else {
@@ -450,37 +456,52 @@ public class AlarmkitPluginImpl: NSObject, FlutterPlugin {
     }
     let soundsUrl = libraryUrl.appendingPathComponent("Sounds")
     let destinationUrl = soundsUrl.appendingPathComponent(fileName)
+    let copyExists = fileManager.fileExists(atPath: destinationUrl.path)
 
-    // 3. Copy the file if it's not already there
-    if !fileManager.fileExists(atPath: destinationUrl.path) {
-        // Check if registrar is initialized
-        if AlarmkitPluginImpl.registrar == nil {
-            NSLog("[flutter_alarmkit] Plugin registrar unavailable; using default sound")
-            return .default
-        }
-
-        // Look up the actual path in the Flutter assets
-        guard let key = AlarmkitPluginImpl.registrar?.lookupKey(forAsset: assetPath),
-              let sourcePath = Bundle.main.path(forResource: key, ofType: nil) else {
-            NSLog("[flutter_alarmkit] Could not find sound asset '\(assetPath)' in bundle; using default sound")
-            return .default
-        }
-
-        do {
-            // Create Library/Sounds directory if needed
-            try fileManager.createDirectory(at: soundsUrl, withIntermediateDirectories: true)
-
-            // Copy the file
-            try fileManager.copyItem(at: URL(fileURLWithPath: sourcePath), to: destinationUrl)
-        } catch {
-            NSLog("[flutter_alarmkit] Failed to copy sound asset; using default sound: \(error)")
-            return .default
-      }
+    // 3. Look up the asset in the bundle — needed even when a copy already
+    // exists, so an asset whose content changed under the same path is
+    // detected and re-copied instead of the stale copy playing forever.
+    guard let registrar = AlarmkitPluginImpl.registrar else {
+        NSLog("[flutter_alarmkit] Plugin registrar unavailable; using \(copyExists ? "existing copy" : "default sound")")
+        return copyExists ? .named(fileName) : .default
+    }
+    let key = registrar.lookupKey(forAsset: assetPath)
+    guard let sourcePath = Bundle.main.path(forResource: key, ofType: nil) else {
+        NSLog("[flutter_alarmkit] Could not find sound asset '\(assetPath)' in bundle; using \(copyExists ? "existing copy" : "default sound")")
+        return copyExists ? .named(fileName) : .default
     }
 
-    // 4. Return just the filename.
+    // 4. Copy when missing or stale. contentsEqual short-circuits on a size
+    // mismatch and alarm sounds are under 30s, so the compare stays cheap.
+    do {
+        if copyExists {
+            if fileManager.contentsEqual(atPath: sourcePath, andPath: destinationUrl.path) {
+                return .named(fileName)
+            }
+            try fileManager.removeItem(at: destinationUrl)
+        }
+
+        // Create Library/Sounds directory if needed
+        try fileManager.createDirectory(at: soundsUrl, withIntermediateDirectories: true)
+
+        // Copy the file
+        try fileManager.copyItem(at: URL(fileURLWithPath: sourcePath), to: destinationUrl)
+    } catch {
+        NSLog("[flutter_alarmkit] Failed to copy sound asset; using default sound: \(error)")
+        return .default
+    }
+
+    // 5. Return just the filename.
     // The system automatically looks in the main bundle and Library/Sounds.
     return .named(fileName)
+  }
+
+  /// Short stable digest of an asset path, used to namespace its copy in
+  /// Library/Sounds. Must be deterministic across launches (Swift's `Hasher`
+  /// is seeded per process), hence SHA-256 rather than `hashValue`.
+  private static func stableDigest(of string: String) -> String {
+    let digest = SHA256.hash(data: Data(string.utf8))
+    return digest.prefix(4).map { String(format: "%02x", $0) }.joined()
   }
 
   private func decodeWeekdays(from mask: Int) -> [Locale.Weekday] {

--- a/lib/flutter_alarmkit.dart
+++ b/lib/flutter_alarmkit.dart
@@ -103,6 +103,11 @@ class FlutterAlarmkit {
   ///   limit, the system will play the default sound instead.
   /// - **Asset Configuration**: Ensure the file is listed in your `pubspec.yaml`
   ///   under `assets`.
+  /// - **Caching**: The asset is copied into the app's `Library/Sounds` folder
+  ///   the first time an alarm uses it. The copy is keyed by the full asset
+  ///   path and refreshed automatically when the asset's content changes, so
+  ///   same-named files in different folders don't collide and edits to the
+  ///   audio file are picked up on the next schedule.
   ///
   /// **How to convert MP3 to CAF:**
   /// You can use `ffmpeg` or `afconvert` (built-in on macOS):
@@ -165,6 +170,11 @@ class FlutterAlarmkit {
   ///   limit, the system will play the default sound instead.
   /// - **Asset Configuration**: Ensure the file is listed in your `pubspec.yaml`
   ///   under `assets`.
+  /// - **Caching**: The asset is copied into the app's `Library/Sounds` folder
+  ///   the first time an alarm uses it. The copy is keyed by the full asset
+  ///   path and refreshed automatically when the asset's content changes, so
+  ///   same-named files in different folders don't collide and edits to the
+  ///   audio file are picked up on the next schedule.
   ///
   /// **How to convert MP3 to CAF:**
   /// You can use `ffmpeg` or `afconvert` (built-in on macOS):
@@ -223,6 +233,11 @@ class FlutterAlarmkit {
   ///   limit, the system will play the default sound instead.
   /// - **Asset Configuration**: Ensure the file is listed in your `pubspec.yaml`
   ///   under `assets`.
+  /// - **Caching**: The asset is copied into the app's `Library/Sounds` folder
+  ///   the first time an alarm uses it. The copy is keyed by the full asset
+  ///   path and refreshed automatically when the asset's content changes, so
+  ///   same-named files in different folders don't collide and edits to the
+  ///   audio file are picked up on the next schedule.
   ///
   /// **How to convert MP3 to CAF:**
   /// You can use `ffmpeg` or `afconvert` (built-in on macOS):

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_alarmkit
 description: "Flutter plugin for Apple AlarmKit (iOS 26+). Schedule one-shot, countdown, and recurring alarms as Lock Screen and Dynamic Island Live Activities."
-version: 0.3.1
+version: 0.3.3
 homepage: https://github.com/gdelataillade/flutter_alarmkit
 
 environment:


### PR DESCRIPTION
Fixes the two `resolveSoundAsset` problems flagged in the codebase audit (#13's deferred findings):

1. **Stale copies**: assets were copied into `Library/Sounds` only when no file with that name existed, so changing a sound's content while keeping its filename meant the old copy played forever — a real trap while iterating on an app.
2. **Basename collisions**: copies were keyed by basename only, so `assets/soft/ring.caf` and `assets/loud/ring.caf` silently clobbered each other (last scheduled wins).

## How

- Copies are now named `<sha256(assetPath) 8-hex-prefix>-<basename>` (e.g. `3ac41f2b-ring.caf`), so distinct asset paths get distinct copies. SHA-256 (CryptoKit) rather than `hashValue` because Swift's `Hasher` is seeded per process — the name must be stable across launches. The name is internal: AlarmKit only uses it to find the file in `Library/Sounds`.
- On every schedule, the bundle asset is compared to the existing copy with `FileManager.contentsEqual` (size short-circuit; alarm sounds are <30s, so the byte compare in the equal-size case is cheap) and re-copied on mismatch. Content refreshes reuse the same copy name, so previously scheduled alarms pick up the new audio too.
- New fallback: if the bundle lookup fails but a copy exists, the existing copy is used instead of silently dropping to the default sound (previously only reachable pre-copy; now that the lookup runs on every call, degrading an already-working sound to `.default` would be a regression).
- Old plain-basename copies are deliberately left in place: alarms scheduled by earlier plugin versions still reference them by name, and `Library/Sounds` can contain files the plugin doesn't own.

Also documents the caching/refresh behavior in the `soundPath` dartdoc of all three schedule methods.

## Version

`0.3.3` + changelog entry. **Assumes #13 (0.3.2) merges first** — if it does, this branch needs a trivial CHANGELOG rebase (both add a heading at the top); if #13 is rejected, retitle this entry 0.3.2.

## Verification

- `flutter analyze` — no issues (strict lints).
- `flutter test` — 53/53 pass.
- `flutter build ios --no-codesign` on `example/` — release build succeeds.
- On-device behavior (stale-copy refresh, collision separation) needs the usual manual pass on an iOS 26 device via the example app: schedule with a custom sound, replace the asset's content keeping the filename, rebuild, reschedule — the new audio should play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
