### PR TITLE
Breaking: control methods throw on UNSUPPORTED_VERSION/BAD_ARGS instead of returning false (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.0
+* **Breaking:** `pauseAlarm`/`resumeAlarm`/`countdownAlarm`/`cancelAlarm`/`stopAlarm` no longer swallow every `PlatformException` as `false`. A `false` return now strictly means "the alarm doesn't exist or isn't in a state the operation applies to"; genuinely exceptional failures — `UNSUPPORTED_VERSION` (iOS < 26) and `BAD_ARGS` (malformed alarm ID) — now throw, matching the schedule methods. **Migration:** if you call these where iOS < 26 is possible, wrap them in `try`/`catch` on `PlatformException` (or gate the calls on `getAuthorizationState()`).
+
 ## 0.3.1
 * Fix `setCountdownAlarm` crashing (AlarmKit precondition trap) when `repeatDurationInSeconds` is `0`.
 * Declare the shared `UserDefaults` (App Group) access in the privacy manifests (plugin + widget) for App Store Required Reason API compliance.

--- a/example/lib/presentation/bloc/alarm_bloc.dart
+++ b/example/lib/presentation/bloc/alarm_bloc.dart
@@ -308,17 +308,29 @@ class AlarmBloc extends Bloc<AlarmEvent, AlarmState> {
     CancelAlarm event,
     Emitter<AlarmState> emit,
   ) async {
-    final canceled = await _repository.cancelAlarm(alarmId: event.alarmId);
-    emit(state.copyWith(scheduleStatus: canceled ? 'Alarm canceled' : 'Error'));
-    add(RefreshAlarms());
+    try {
+      final canceled = await _repository.cancelAlarm(alarmId: event.alarmId);
+      emit(state.copyWith(
+        scheduleStatus: canceled ? 'Alarm canceled' : 'Alarm not found',
+      ));
+      add(RefreshAlarms());
+    } catch (e) {
+      emit(state.copyWith(scheduleStatus: 'Error: $e'));
+    }
   }
 
   Future<void> _onStopAlarm(
     StopAlarm event,
     Emitter<AlarmState> emit,
   ) async {
-    final stopped = await _repository.stopAlarm(alarmId: event.alarmId);
-    emit(state.copyWith(scheduleStatus: stopped ? 'Alarm stopped' : 'Error'));
-    add(RefreshAlarms());
+    try {
+      final stopped = await _repository.stopAlarm(alarmId: event.alarmId);
+      emit(state.copyWith(
+        scheduleStatus: stopped ? 'Alarm stopped' : 'Alarm not found',
+      ));
+      add(RefreshAlarms());
+    } catch (e) {
+      emit(state.copyWith(scheduleStatus: 'Error: $e'));
+    }
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.1"
+    version: "0.4.0"
   flutter_bloc:
     dependency: "direct main"
     description:

--- a/lib/flutter_alarmkit.dart
+++ b/lib/flutter_alarmkit.dart
@@ -278,8 +278,10 @@ class FlutterAlarmkit {
   /// [alarmId] is the UUID of the alarm to cancel.
   ///
   /// Returns a [Future<bool>] that completes with `true` if the alarm was
-  /// canceled, `false` if the operation failed (e.g. the alarm doesn't exist, or the
-  /// system rejected the request).
+  /// canceled, or `false` if it couldn't be (e.g. the alarm doesn't exist).
+  ///
+  /// Throws a [PlatformException] if the platform version is not supported
+  /// (iOS < 26.0) or [alarmId] is not a valid UUID string.
   Future<bool> cancelAlarm({required String alarmId}) {
     return FlutterAlarmkitPlatform.instance.cancelAlarm(alarmId: alarmId);
   }
@@ -303,8 +305,11 @@ class FlutterAlarmkit {
   /// [alarmId] is the UUID of the alarm to pause.
   ///
   /// Returns a [Future<bool>] that completes with `true` if the alarm was
-  /// paused, `false` if the operation failed (e.g. the alarm doesn't exist, or the
-  /// system rejected the request).
+  /// paused, or `false` if it couldn't be (e.g. the alarm doesn't exist or
+  /// isn't in the countdown state).
+  ///
+  /// Throws a [PlatformException] if the platform version is not supported
+  /// (iOS < 26.0) or [alarmId] is not a valid UUID string.
   Future<bool> pauseAlarm({required String alarmId}) {
     return FlutterAlarmkitPlatform.instance.pauseAlarm(alarmId: alarmId);
   }
@@ -314,8 +319,11 @@ class FlutterAlarmkit {
   /// [alarmId] is the UUID of the alarm to resume.
   ///
   /// Returns a [Future<bool>] that completes with `true` if the alarm was
-  /// resumed, `false` if the operation failed (e.g. the alarm doesn't exist, or the
-  /// system rejected the request).
+  /// resumed, or `false` if it couldn't be (e.g. the alarm doesn't exist or
+  /// isn't in the paused state).
+  ///
+  /// Throws a [PlatformException] if the platform version is not supported
+  /// (iOS < 26.0) or [alarmId] is not a valid UUID string.
   Future<bool> resumeAlarm({required String alarmId}) {
     return FlutterAlarmkitPlatform.instance.resumeAlarm(alarmId: alarmId);
   }
@@ -329,8 +337,12 @@ class FlutterAlarmkit {
   ///
   /// [alarmId] is the UUID of the alarm to restart the countdown for.
   ///
-  /// Returns a [Future<bool>] that completes with `true` on success,
-  /// `false` if the operation failed (e.g. the alarm doesn't exist).
+  /// Returns a [Future<bool>] that completes with `true` on success, or
+  /// `false` if the countdown couldn't be restarted (e.g. the alarm doesn't
+  /// exist or isn't a countdown alarm).
+  ///
+  /// Throws a [PlatformException] if the platform version is not supported
+  /// (iOS < 26.0) or [alarmId] is not a valid UUID string.
   Future<bool> countdownAlarm({required String alarmId}) {
     return FlutterAlarmkitPlatform.instance.countdownAlarm(alarmId: alarmId);
   }
@@ -343,8 +355,10 @@ class FlutterAlarmkit {
   /// [alarmId] is the UUID of the alarm to stop.
   ///
   /// Returns a [Future<bool>] that completes with `true` if the alarm was
-  /// stopped, `false` if the operation failed (e.g. the alarm doesn't exist, or the
-  /// system rejected the request).
+  /// stopped, or `false` if it couldn't be (e.g. the alarm doesn't exist).
+  ///
+  /// Throws a [PlatformException] if the platform version is not supported
+  /// (iOS < 26.0) or [alarmId] is not a valid UUID string.
   Future<bool> stopAlarm({required String alarmId}) {
     return FlutterAlarmkitPlatform.instance.stopAlarm(alarmId: alarmId);
   }

--- a/lib/flutter_alarmkit_method_channel.dart
+++ b/lib/flutter_alarmkit_method_channel.dart
@@ -198,66 +198,20 @@ class MethodChannelFlutterAlarmkit extends FlutterAlarmkitPlatform {
   }
 
   @override
-  Future<bool> pauseAlarm({required String alarmId}) async {
-    try {
-      return await methodChannel.invokeMethod<bool>('pauseAlarm', alarmId) ??
-          false;
-    } on PlatformException catch (e) {
-      debugPrint(
-        '[FlutterAlarmkit] Failed to pause alarm $alarmId: [${e.code}] ${e.message}',
-      );
-      return false;
-    }
-  }
+  Future<bool> pauseAlarm({required String alarmId}) =>
+      _controlAlarm('pauseAlarm', alarmId);
 
   @override
-  Future<bool> resumeAlarm({required String alarmId}) async {
-    try {
-      return await methodChannel.invokeMethod<bool>('resumeAlarm', alarmId) ??
-          false;
-    } on PlatformException catch (e) {
-      debugPrint(
-        '[FlutterAlarmkit] Failed to resume alarm $alarmId: [${e.code}] ${e.message}',
-      );
-      return false;
-    }
-  }
+  Future<bool> resumeAlarm({required String alarmId}) =>
+      _controlAlarm('resumeAlarm', alarmId);
 
   @override
-  Future<bool> countdownAlarm({required String alarmId}) async {
-    try {
-      return await methodChannel.invokeMethod<bool>(
-            'countdownAlarm',
-            alarmId,
-          ) ??
-          false;
-    } on PlatformException catch (e) {
-      debugPrint(
-        '[FlutterAlarmkit] Failed to countdown alarm $alarmId: [${e.code}] ${e.message}',
-      );
-      return false;
-    }
-  }
+  Future<bool> countdownAlarm({required String alarmId}) =>
+      _controlAlarm('countdownAlarm', alarmId);
 
   @override
-  Future<bool> cancelAlarm({required String alarmId}) async {
-    try {
-      final result =
-          await methodChannel.invokeMethod<bool>('cancelAlarm', alarmId) ??
-          false;
-
-      debugPrint(
-        '[FlutterAlarmkit] Alarm $alarmId was cancelled successfully',
-      );
-
-      return result;
-    } on PlatformException catch (e) {
-      debugPrint(
-        '[FlutterAlarmkit] Failed to cancel alarm $alarmId: [${e.code}] ${e.message}',
-      );
-      return false;
-    }
-  }
+  Future<bool> cancelAlarm({required String alarmId}) =>
+      _controlAlarm('cancelAlarm', alarmId);
 
   @override
   Future<void> cancelAll() async {
@@ -269,23 +223,33 @@ class MethodChannelFlutterAlarmkit extends FlutterAlarmkitPlatform {
   }
 
   @override
-  Future<bool> stopAlarm({required String alarmId}) async {
+  Future<bool> stopAlarm({required String alarmId}) =>
+      _controlAlarm('stopAlarm', alarmId);
+
+  /// Error codes the native side raises when an alarm can't be controlled —
+  /// it doesn't exist, or it isn't in a state the operation applies to.
+  /// These map to a `false` return; every other code (`UNSUPPORTED_VERSION`,
+  /// `BAD_ARGS`, ...) is genuinely exceptional and propagates.
+  static const _controlFailureCodes = {
+    'PAUSE_ERROR',
+    'RESUME_ERROR',
+    'COUNTDOWN_ERROR',
+    'CANCEL_ERROR',
+    'STOP_ERROR',
+  };
+
+  /// Shared implementation of the five alarm-control methods.
+  Future<bool> _controlAlarm(String method, String alarmId) async {
     try {
-      final stopped =
-          await methodChannel.invokeMethod<bool>('stopAlarm', alarmId) ?? false;
-
-      if (stopped) {
-        debugPrint(
-          '[FlutterAlarmkit] Alarm $alarmId was stopped successfully',
-        );
-      }
-
-      return stopped;
+      return await methodChannel.invokeMethod<bool>(method, alarmId) ?? false;
     } on PlatformException catch (e) {
-      debugPrint(
-        '[FlutterAlarmkit] Failed to stop alarm $alarmId: [${e.code}] ${e.message}',
-      );
-      return false;
+      if (_controlFailureCodes.contains(e.code)) {
+        debugPrint(
+          '[FlutterAlarmkit] $method($alarmId) failed: [${e.code}] ${e.message}',
+        );
+        return false;
+      }
+      _rethrowMapped(e);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_alarmkit
 description: "Flutter plugin for Apple AlarmKit (iOS 26+). Schedule one-shot, countdown, and recurring alarms as Lock Screen and Dynamic Island Live Activities."
-version: 0.3.1
+version: 0.4.0
 homepage: https://github.com/gdelataillade/flutter_alarmkit
 
 environment:

--- a/test/flutter_alarmkit_method_channel_test.dart
+++ b/test/flutter_alarmkit_method_channel_test.dart
@@ -127,6 +127,86 @@ void main() {
     );
   });
 
+  group('alarm control error contract', () {
+    // Each control method mapped to the native error code that means
+    // "alarm not found / not in a controllable state".
+    final controls = <String, ({Future<bool> Function() call, String code})>{
+      'pauseAlarm': (
+        call: () => platform.pauseAlarm(alarmId: 'id-1'),
+        code: 'PAUSE_ERROR',
+      ),
+      'resumeAlarm': (
+        call: () => platform.resumeAlarm(alarmId: 'id-1'),
+        code: 'RESUME_ERROR',
+      ),
+      'countdownAlarm': (
+        call: () => platform.countdownAlarm(alarmId: 'id-1'),
+        code: 'COUNTDOWN_ERROR',
+      ),
+      'cancelAlarm': (
+        call: () => platform.cancelAlarm(alarmId: 'id-1'),
+        code: 'CANCEL_ERROR',
+      ),
+      'stopAlarm': (
+        call: () => platform.stopAlarm(alarmId: 'id-1'),
+        code: 'STOP_ERROR',
+      ),
+    };
+
+    for (final MapEntry(key: method, value: control) in controls.entries) {
+      test('$method returns true when the platform succeeds', () async {
+        messenger.setMockMethodCallHandler(channel, (call) async {
+          expect(call.method, method);
+          expect(call.arguments, 'id-1');
+          return true;
+        });
+
+        expect(await control.call(), isTrue);
+      });
+
+      test('$method returns false on ${control.code}', () async {
+        messenger.setMockMethodCallHandler(channel, (call) async {
+          throw PlatformException(code: control.code, message: 'not found');
+        });
+
+        expect(await control.call(), isFalse);
+      });
+
+      test('$method rethrows UNSUPPORTED_VERSION with the mapped message',
+          () async {
+        messenger.setMockMethodCallHandler(channel, (call) async {
+          throw PlatformException(code: 'UNSUPPORTED_VERSION');
+        });
+
+        await expectLater(
+          control.call(),
+          throwsA(
+            isA<PlatformException>()
+                .having((e) => e.code, 'code', 'UNSUPPORTED_VERSION')
+                .having(
+                  (e) => e.message,
+                  'message',
+                  'AlarmKit is only available on iOS 26.0 and above',
+                ),
+          ),
+        );
+      });
+
+      test('$method rethrows BAD_ARGS', () async {
+        messenger.setMockMethodCallHandler(channel, (call) async {
+          throw PlatformException(code: 'BAD_ARGS', message: 'bad id');
+        });
+
+        await expectLater(
+          control.call(),
+          throwsA(
+            isA<PlatformException>().having((e) => e.code, 'code', 'BAD_ARGS'),
+          ),
+        );
+      });
+    }
+  });
+
   test('schedule forwards the metadata map into the call arguments', () async {
     Map<dynamic, dynamic>? captured;
     messenger.setMockMethodCallHandler(channel, (call) async {


### PR DESCRIPTION
Fixes the error-contract inconsistency flagged in the codebase audit (#13's deferred findings): the five control methods (`pauseAlarm`/`resumeAlarm`/`countdownAlarm`/`cancelAlarm`/`stopAlarm`) swallowed **every** `PlatformException` and returned `false`, so `UNSUPPORTED_VERSION` (iOS < 26) was indistinguishable from "alarm doesn't exist", while the schedule methods throw.

## New contract

- `false` strictly means **the alarm couldn't be controlled**: it doesn't exist, or isn't in a state the operation applies to. These are exactly the per-method codes the native side raises when AlarmKit's operation throws (`PAUSE_ERROR`, `RESUME_ERROR`, `COUNTDOWN_ERROR`, `CANCEL_ERROR`, `STOP_ERROR`) — the native layer never returns `false` itself.
- Everything else **throws**, matching the schedule methods: `UNSUPPORTED_VERSION` (with the clearer mapped message), `BAD_ARGS` (malformed alarm ID — a programmer error that deserves a loud failure), and any unknown future code (propagating unknowns is the safe default).

The five near-identical method-channel implementations collapse into a single `_controlAlarm` helper with an explicit allowlist of control-failure codes.

## Breaking change → 0.4.0

Pre-1.0, clean API preferred over back-compat (maintainer's call). Migration is in the CHANGELOG: wrap control calls in `try`/`catch` on `PlatformException` where iOS < 26 is possible, or gate on `getAuthorizationState()`.

## Also

- Dartdoc on all five public methods updated to state the exact `false` semantics and throw conditions.
- Example app: the cancel/stop bloc handlers now catch and surface errors (previously an `UNSUPPORTED_VERSION` throw would have been an unhandled async error).
- 20 new channel tests (5 methods × 4 behaviors: success, `*_ERROR` → `false`, `UNSUPPORTED_VERSION` rethrown with mapped message, `BAD_ARGS` rethrown).

README has no error-handling notes for these methods, so nothing to update there.

## Version stacking note

Third PR based on `main` (0.3.1) while #13 (0.3.2) and #15 (0.3.3) are open — whichever merges later needs a trivial CHANGELOG rebase (all three add a heading at the top). The 0.4.0 heading is correct regardless of merge order.

## Verification

- `flutter analyze` — no issues (strict lints).
- `flutter test` — 73/73 pass (53 existing + 20 new).
- Dart-only change (no Swift touched), so analyze + tests are full coverage; on-device behavior of the five methods is unchanged for the not-found cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
