### PR TITLE
Fix black title text in dark mode (example app)

### DIFF
--- a/example/lib/presentation/widgets/alarm_controls.dart
+++ b/example/lib/presentation/widgets/alarm_controls.dart
@@ -221,11 +221,11 @@ class _AlarmControlsState extends State<AlarmControls> {
                       children: [
                         const Icon(CupertinoIcons.square_grid_2x2, size: 19),
                         const SizedBox(width: 11),
-                        const Expanded(
+                        Expanded(
                           child: Text(
                             'More examples',
                             style: TextStyle(
-                              color: CupertinoColors.label,
+                              color: CupertinoColors.label.resolveFrom(context),
                               fontSize: 16,
                               fontWeight: FontWeight.w600,
                             ),
@@ -443,8 +443,8 @@ class _ExampleRow extends StatelessWidget {
                 children: [
                   Text(
                     action.title,
-                    style: const TextStyle(
-                      color: CupertinoColors.label,
+                    style: TextStyle(
+                      color: CupertinoColors.label.resolveFrom(context),
                       fontSize: 15,
                       fontWeight: FontWeight.w600,
                     ),

--- a/example/lib/presentation/widgets/log_panel.dart
+++ b/example/lib/presentation/widgets/log_panel.dart
@@ -29,11 +29,11 @@ class _LogPanelState extends State<LogPanel> {
                 const Icon(CupertinoIcons.chevron_left_slash_chevron_right,
                     size: 19),
                 const SizedBox(width: 11),
-                const Expanded(
+                Expanded(
                   child: Text(
                     'Plugin logs',
                     style: TextStyle(
-                      color: CupertinoColors.label,
+                      color: CupertinoColors.label.resolveFrom(context),
                       fontSize: 15,
                       fontWeight: FontWeight.w600,
                     ),


### PR DESCRIPTION
In dark mode, the **More examples** and **Plugin logs** headers and the example row titles (e.g. **Medication alarm**) rendered as black text on the dark surface — unreadable.

## Cause

`CupertinoColors.label` is a `CupertinoDynamicColor`. When placed directly into a `TextStyle`, it's never resolved against the current brightness, so the text painter uses its default (light-mode) value — opaque black. The rest of the app that resolves correctly (e.g. `_QuickAction`) already calls `.resolveFrom(context)`.

## Fix

Resolve the three unresolved `CupertinoColors.label` usages with `.resolveFrom(context)` (`alarm_controls.dart` ×2, `log_panel.dart` ×1). One `const` is dropped per site since the color is now context-dependent.

## Not included (flagged separately)

The same root cause affects every `ExampleTheme.secondaryText` usage (17 sites across 4 files) and the `systemGrey` status dot — all render the light-mode gray in dark mode (~3.3:1 contrast vs. the theme's intended lighter dark variant). Those weren't reported as unreadable and sit in `const`-heavy trees, so I left them out of this focused fix.

## Verification

- `flutter analyze` — no issues.
- Visual check on-device in dark mode still recommended (iOS Cupertino app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)